### PR TITLE
Implement ONNX backend emitter

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "crates/nxpu-ir",
     "crates/nxpu-opt",
     "crates/nxpu-backend-core",
+    "crates/nxpu-backend-onnx",
     "crates/nxpu-cli",
 ]
 

--- a/crates/nxpu-backend-onnx/Cargo.toml
+++ b/crates/nxpu-backend-onnx/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "nxpu-backend-onnx"
+description = "ONNX backend emitter for NxPU"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+nxpu-ir = { path = "../nxpu-ir" }
+nxpu-backend-core = { path = "../nxpu-backend-core" }
+prost = "0.13"
+thiserror = "2"
+
+[dev-dependencies]
+nxpu-parser = { path = "../nxpu-parser" }

--- a/crates/nxpu-backend-onnx/src/analyze.rs
+++ b/crates/nxpu-backend-onnx/src/analyze.rs
@@ -1,0 +1,671 @@
+//! IR pattern classification for ONNX lowering.
+//!
+//! Analyzes an entry point's global variables and function body to classify
+//! the computation into a known ONNX-mappable pattern (MatMul, ElementWise).
+
+use nxpu_ir::{
+    AddressSpace, Arena, BinaryOp, Expression, GlobalVariable, Handle, Module, Scalar, ScalarKind,
+    Statement, StorageAccess, TypeInner,
+};
+
+use crate::proto::data_type;
+
+/// Errors during IR pattern analysis.
+#[derive(Debug, thiserror::Error)]
+pub enum AnalysisError {
+    #[error("no entry points in module")]
+    NoEntryPoints,
+    #[error("entry point index {0} out of range")]
+    EntryPointOutOfRange(usize),
+    #[error("unsupported pattern: {0}")]
+    UnsupportedPattern(String),
+    #[error("missing uniform params struct")]
+    MissingParams,
+}
+
+/// Role of a tensor in the computation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TensorRole {
+    Input,
+    Output,
+}
+
+/// A storage buffer bound as a tensor.
+#[derive(Debug, Clone)]
+pub struct TensorBinding {
+    pub handle: Handle<GlobalVariable>,
+    pub name: String,
+    pub elem_type: i32,
+    pub role: TensorRole,
+}
+
+/// Symbolic dimension names for matrix multiplication.
+#[derive(Debug, Clone)]
+pub struct MatMulShape {
+    pub m: String,
+    pub n: String,
+    pub k: String,
+}
+
+/// Element-wise binary operation kind.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ElementWiseOp {
+    Add,
+    Sub,
+    Mul,
+    Div,
+}
+
+impl ElementWiseOp {
+    /// Returns the ONNX operator type string.
+    pub fn onnx_op_type(self) -> &'static str {
+        match self {
+            Self::Add => "Add",
+            Self::Sub => "Sub",
+            Self::Mul => "Mul",
+            Self::Div => "Div",
+        }
+    }
+}
+
+/// A classified kernel pattern that maps to ONNX operators.
+#[derive(Debug, Clone)]
+pub enum KernelPattern {
+    /// Loop + accumulation + 2 read arrays + 1 write array → ONNX `MatMul`.
+    MatMul {
+        inputs: [TensorBinding; 2],
+        output: TensorBinding,
+        shape: MatMulShape,
+    },
+    /// No loop + binary op on arrays → ONNX `Add`/`Sub`/`Mul`/`Div`.
+    ElementWise {
+        op: ElementWiseOp,
+        inputs: [TensorBinding; 2],
+        output: TensorBinding,
+        dim_name: String,
+    },
+}
+
+/// Classify an entry point into a known ONNX-mappable pattern.
+pub fn classify_entry_point(
+    module: &Module,
+    ep_index: usize,
+) -> Result<KernelPattern, AnalysisError> {
+    if module.entry_points.is_empty() {
+        return Err(AnalysisError::NoEntryPoints);
+    }
+    let ep = module
+        .entry_points
+        .get(ep_index)
+        .ok_or(AnalysisError::EntryPointOutOfRange(ep_index))?;
+
+    // 1. Classify globals by address space.
+    let mut inputs: Vec<(Handle<GlobalVariable>, &nxpu_ir::GlobalVariable)> = Vec::new();
+    let mut outputs: Vec<(Handle<GlobalVariable>, &nxpu_ir::GlobalVariable)> = Vec::new();
+    let mut params_members: Option<&[nxpu_ir::StructMember]> = None;
+
+    for (handle, gv) in module.global_variables.iter() {
+        match &gv.space {
+            AddressSpace::Storage { access } => {
+                if access.contains(StorageAccess::STORE) {
+                    outputs.push((handle, gv));
+                } else {
+                    inputs.push((handle, gv));
+                }
+            }
+            AddressSpace::Uniform => {
+                if let TypeInner::Struct { members, .. } = &module.types[gv.ty].inner {
+                    params_members = Some(members);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    // Sort inputs by resource binding order (binding 0 = A, binding 1 = B).
+    inputs.sort_by_key(|(_, gv)| gv.binding.map(|b| b.binding).unwrap_or(u32::MAX));
+
+    if inputs.len() < 2 || outputs.is_empty() {
+        return Err(AnalysisError::UnsupportedPattern(
+            "expected at least 2 input and 1 output storage buffers".into(),
+        ));
+    }
+
+    // 2. Build tensor bindings.
+    let input_a = make_binding(module, inputs[0].0, inputs[0].1, TensorRole::Input);
+    let input_b = make_binding(module, inputs[1].0, inputs[1].1, TensorRole::Input);
+    let output_c = make_binding(module, outputs[0].0, outputs[0].1, TensorRole::Output);
+
+    // 3. Detect pattern from function body structure.
+    if has_loop(&ep.function.body) {
+        // MatMul: loop + accumulation pattern.
+        let shape_names: Vec<String> = params_members
+            .ok_or(AnalysisError::MissingParams)?
+            .iter()
+            .filter_map(|m| m.name.clone())
+            .collect();
+
+        let shape = if shape_names.len() >= 3 {
+            MatMulShape {
+                m: shape_names[0].clone(),
+                n: shape_names[1].clone(),
+                k: shape_names[2].clone(),
+            }
+        } else {
+            MatMulShape {
+                m: "M".into(),
+                n: "N".into(),
+                k: "K".into(),
+            }
+        };
+
+        Ok(KernelPattern::MatMul {
+            inputs: [input_a, input_b],
+            output: output_c,
+            shape,
+        })
+    } else {
+        // ElementWise: store of binary operation.
+        let op =
+            find_store_binary_op(&ep.function.body, &ep.function.expressions).ok_or_else(|| {
+                AnalysisError::UnsupportedPattern("no recognizable binary operation found".into())
+            })?;
+
+        let dim_name = params_members
+            .and_then(|members| members.first())
+            .and_then(|m| m.name.clone())
+            .unwrap_or_else(|| "N".into());
+
+        Ok(KernelPattern::ElementWise {
+            op,
+            inputs: [input_a, input_b],
+            output: output_c,
+            dim_name,
+        })
+    }
+}
+
+fn make_binding(
+    module: &Module,
+    handle: Handle<GlobalVariable>,
+    gv: &nxpu_ir::GlobalVariable,
+    role: TensorRole,
+) -> TensorBinding {
+    let elem_type = resolve_array_elem_type(module, gv.ty).unwrap_or(data_type::FLOAT);
+    TensorBinding {
+        handle,
+        name: gv
+            .name
+            .clone()
+            .unwrap_or_else(|| format!("tensor_{}", handle.index())),
+        elem_type,
+        role,
+    }
+}
+
+/// Resolve an array type to its element's ONNX data type.
+fn resolve_array_elem_type(module: &Module, ty: nxpu_ir::Handle<nxpu_ir::Type>) -> Option<i32> {
+    match &module.types[ty].inner {
+        TypeInner::Array { base, .. } => match &module.types[*base].inner {
+            TypeInner::Scalar(s) => Some(scalar_to_onnx_data_type(s)),
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
+/// Map an IR scalar type to an ONNX data type constant.
+fn scalar_to_onnx_data_type(scalar: &Scalar) -> i32 {
+    match (scalar.kind, scalar.width) {
+        (ScalarKind::Float, 4) => data_type::FLOAT,
+        (ScalarKind::Float, 2) => data_type::FLOAT16,
+        (ScalarKind::Sint, 4) => data_type::INT32,
+        (ScalarKind::Uint, 4) => data_type::UINT32,
+        (ScalarKind::Bool, _) => data_type::BOOL,
+        _ => data_type::FLOAT,
+    }
+}
+
+/// Check if a block (or any nested block) contains a Loop statement.
+fn has_loop(body: &[Statement]) -> bool {
+    body.iter().any(|stmt| match stmt {
+        Statement::Loop { .. } => true,
+        Statement::If { accept, reject, .. } => has_loop(accept) || has_loop(reject),
+        _ => false,
+    })
+}
+
+/// Search a block for a Store whose value is a Binary expression,
+/// returning the corresponding element-wise op.
+fn find_store_binary_op(body: &[Statement], exprs: &Arena<Expression>) -> Option<ElementWiseOp> {
+    for stmt in body {
+        match stmt {
+            Statement::Store { value, .. } => {
+                if let Some(Expression::Binary { op, .. }) = exprs.try_get(*value) {
+                    let ew = match op {
+                        BinaryOp::Add => ElementWiseOp::Add,
+                        BinaryOp::Subtract => ElementWiseOp::Sub,
+                        BinaryOp::Multiply => ElementWiseOp::Mul,
+                        BinaryOp::Divide => ElementWiseOp::Div,
+                        _ => continue,
+                    };
+                    return Some(ew);
+                }
+            }
+            Statement::If { accept, reject, .. } => {
+                if let Some(op) = find_store_binary_op(accept, exprs) {
+                    return Some(op);
+                }
+                if let Some(op) = find_store_binary_op(reject, exprs) {
+                    return Some(op);
+                }
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nxpu_ir::*;
+
+    fn make_matmul_module() -> Module {
+        let mut module = Module::default();
+
+        let f32_ty = module.types.insert(Type {
+            name: None,
+            inner: TypeInner::Scalar(Scalar::F32),
+        });
+        let u32_ty = module.types.insert(Type {
+            name: None,
+            inner: TypeInner::Scalar(Scalar::U32),
+        });
+        let array_f32 = module.types.insert(Type {
+            name: None,
+            inner: TypeInner::Array {
+                base: f32_ty,
+                size: ArraySize::Dynamic,
+                stride: 4,
+            },
+        });
+        let params_ty = module.types.insert(Type {
+            name: Some("Params".into()),
+            inner: TypeInner::Struct {
+                members: vec![
+                    StructMember {
+                        name: Some("M".into()),
+                        ty: u32_ty,
+                        offset: 0,
+                    },
+                    StructMember {
+                        name: Some("N".into()),
+                        ty: u32_ty,
+                        offset: 4,
+                    },
+                    StructMember {
+                        name: Some("K".into()),
+                        ty: u32_ty,
+                        offset: 8,
+                    },
+                ],
+                span: 12,
+            },
+        });
+
+        module.global_variables.append(GlobalVariable {
+            name: Some("a".into()),
+            space: AddressSpace::Storage {
+                access: StorageAccess::LOAD,
+            },
+            binding: Some(ResourceBinding {
+                group: 0,
+                binding: 0,
+            }),
+            ty: array_f32,
+            init: None,
+        });
+        module.global_variables.append(GlobalVariable {
+            name: Some("b".into()),
+            space: AddressSpace::Storage {
+                access: StorageAccess::LOAD,
+            },
+            binding: Some(ResourceBinding {
+                group: 0,
+                binding: 1,
+            }),
+            ty: array_f32,
+            init: None,
+        });
+        module.global_variables.append(GlobalVariable {
+            name: Some("result".into()),
+            space: AddressSpace::Storage {
+                access: StorageAccess::LOAD | StorageAccess::STORE,
+            },
+            binding: Some(ResourceBinding {
+                group: 0,
+                binding: 2,
+            }),
+            ty: array_f32,
+            init: None,
+        });
+        module.global_variables.append(GlobalVariable {
+            name: Some("params".into()),
+            space: AddressSpace::Uniform,
+            binding: Some(ResourceBinding {
+                group: 0,
+                binding: 3,
+            }),
+            ty: params_ty,
+            init: None,
+        });
+
+        // Entry point with a loop in the body (triggers MatMul detection).
+        let mut func = Function::new("main");
+        func.body.push(Statement::Loop {
+            body: vec![Statement::Break],
+            continuing: vec![],
+            break_if: None,
+        });
+
+        module.entry_points.push(EntryPoint {
+            name: "main".into(),
+            workgroup_size: [16, 16, 1],
+            function: func,
+        });
+
+        module
+    }
+
+    fn make_elementwise_module(op: BinaryOp) -> Module {
+        let mut module = Module::default();
+
+        let f32_ty = module.types.insert(Type {
+            name: None,
+            inner: TypeInner::Scalar(Scalar::F32),
+        });
+        let u32_ty = module.types.insert(Type {
+            name: None,
+            inner: TypeInner::Scalar(Scalar::U32),
+        });
+        let array_f32 = module.types.insert(Type {
+            name: None,
+            inner: TypeInner::Array {
+                base: f32_ty,
+                size: ArraySize::Dynamic,
+                stride: 4,
+            },
+        });
+        let params_ty = module.types.insert(Type {
+            name: Some("Params".into()),
+            inner: TypeInner::Struct {
+                members: vec![StructMember {
+                    name: Some("N".into()),
+                    ty: u32_ty,
+                    offset: 0,
+                }],
+                span: 4,
+            },
+        });
+
+        module.global_variables.append(GlobalVariable {
+            name: Some("a".into()),
+            space: AddressSpace::Storage {
+                access: StorageAccess::LOAD,
+            },
+            binding: Some(ResourceBinding {
+                group: 0,
+                binding: 0,
+            }),
+            ty: array_f32,
+            init: None,
+        });
+        module.global_variables.append(GlobalVariable {
+            name: Some("b".into()),
+            space: AddressSpace::Storage {
+                access: StorageAccess::LOAD,
+            },
+            binding: Some(ResourceBinding {
+                group: 0,
+                binding: 1,
+            }),
+            ty: array_f32,
+            init: None,
+        });
+        module.global_variables.append(GlobalVariable {
+            name: Some("c".into()),
+            space: AddressSpace::Storage {
+                access: StorageAccess::LOAD | StorageAccess::STORE,
+            },
+            binding: Some(ResourceBinding {
+                group: 0,
+                binding: 2,
+            }),
+            ty: array_f32,
+            init: None,
+        });
+        module.global_variables.append(GlobalVariable {
+            name: Some("params".into()),
+            space: AddressSpace::Uniform,
+            binding: Some(ResourceBinding {
+                group: 0,
+                binding: 3,
+            }),
+            ty: params_ty,
+            init: None,
+        });
+
+        // Entry point with Store of Binary (no loop → ElementWise).
+        let mut func = Function::new("main");
+        let left = func
+            .expressions
+            .append(Expression::Literal(Literal::F32(1.0)));
+        let right = func
+            .expressions
+            .append(Expression::Literal(Literal::F32(2.0)));
+        let binary = func
+            .expressions
+            .append(Expression::Binary { op, left, right });
+        let ptr = func
+            .expressions
+            .append(Expression::Literal(Literal::F32(0.0)));
+        func.body.push(Statement::Store {
+            pointer: ptr,
+            value: binary,
+        });
+
+        module.entry_points.push(EntryPoint {
+            name: "vecadd".into(),
+            workgroup_size: [256, 1, 1],
+            function: func,
+        });
+
+        module
+    }
+
+    #[test]
+    fn classify_matmul() {
+        let module = make_matmul_module();
+        let pattern = classify_entry_point(&module, 0).unwrap();
+        match pattern {
+            KernelPattern::MatMul {
+                inputs,
+                output,
+                shape,
+            } => {
+                assert_eq!(inputs[0].name, "a");
+                assert_eq!(inputs[1].name, "b");
+                assert_eq!(output.name, "result");
+                assert_eq!(inputs[0].elem_type, data_type::FLOAT);
+                assert_eq!(shape.m, "M");
+                assert_eq!(shape.n, "N");
+                assert_eq!(shape.k, "K");
+            }
+            _ => panic!("expected MatMul pattern"),
+        }
+    }
+
+    #[test]
+    fn classify_elementwise_add() {
+        let module = make_elementwise_module(BinaryOp::Add);
+        let pattern = classify_entry_point(&module, 0).unwrap();
+        match pattern {
+            KernelPattern::ElementWise {
+                op,
+                inputs,
+                output,
+                dim_name,
+            } => {
+                assert_eq!(op, ElementWiseOp::Add);
+                assert_eq!(inputs[0].name, "a");
+                assert_eq!(inputs[1].name, "b");
+                assert_eq!(output.name, "c");
+                assert_eq!(dim_name, "N");
+            }
+            _ => panic!("expected ElementWise pattern"),
+        }
+    }
+
+    #[test]
+    fn classify_elementwise_div() {
+        let module = make_elementwise_module(BinaryOp::Divide);
+        let pattern = classify_entry_point(&module, 0).unwrap();
+        match &pattern {
+            KernelPattern::ElementWise { op, .. } => {
+                assert_eq!(*op, ElementWiseOp::Div);
+            }
+            _ => panic!("expected ElementWise pattern"),
+        }
+    }
+
+    #[test]
+    fn classify_out_of_range() {
+        let module = make_matmul_module();
+        let err = classify_entry_point(&module, 99).unwrap_err();
+        assert!(matches!(err, AnalysisError::EntryPointOutOfRange(99)));
+    }
+
+    #[test]
+    fn classify_empty_module() {
+        let module = Module::default();
+        let err = classify_entry_point(&module, 0).unwrap_err();
+        assert!(matches!(err, AnalysisError::NoEntryPoints));
+    }
+
+    #[test]
+    fn input_sorted_by_binding() {
+        // Build a module where 'b' (binding 1) is appended before 'a' (binding 0)
+        // to verify that classify sorts inputs by binding order.
+        let mut module = Module::default();
+
+        let f32_ty = module.types.insert(Type {
+            name: None,
+            inner: TypeInner::Scalar(Scalar::F32),
+        });
+        let u32_ty = module.types.insert(Type {
+            name: None,
+            inner: TypeInner::Scalar(Scalar::U32),
+        });
+        let array_f32 = module.types.insert(Type {
+            name: None,
+            inner: TypeInner::Array {
+                base: f32_ty,
+                size: ArraySize::Dynamic,
+                stride: 4,
+            },
+        });
+        let params_ty = module.types.insert(Type {
+            name: Some("Params".into()),
+            inner: TypeInner::Struct {
+                members: vec![
+                    StructMember {
+                        name: Some("M".into()),
+                        ty: u32_ty,
+                        offset: 0,
+                    },
+                    StructMember {
+                        name: Some("N".into()),
+                        ty: u32_ty,
+                        offset: 4,
+                    },
+                    StructMember {
+                        name: Some("K".into()),
+                        ty: u32_ty,
+                        offset: 8,
+                    },
+                ],
+                span: 12,
+            },
+        });
+
+        // Append b (binding 1) BEFORE a (binding 0).
+        module.global_variables.append(GlobalVariable {
+            name: Some("b".into()),
+            space: AddressSpace::Storage {
+                access: StorageAccess::LOAD,
+            },
+            binding: Some(ResourceBinding {
+                group: 0,
+                binding: 1,
+            }),
+            ty: array_f32,
+            init: None,
+        });
+        module.global_variables.append(GlobalVariable {
+            name: Some("a".into()),
+            space: AddressSpace::Storage {
+                access: StorageAccess::LOAD,
+            },
+            binding: Some(ResourceBinding {
+                group: 0,
+                binding: 0,
+            }),
+            ty: array_f32,
+            init: None,
+        });
+        module.global_variables.append(GlobalVariable {
+            name: Some("result".into()),
+            space: AddressSpace::Storage {
+                access: StorageAccess::LOAD | StorageAccess::STORE,
+            },
+            binding: Some(ResourceBinding {
+                group: 0,
+                binding: 2,
+            }),
+            ty: array_f32,
+            init: None,
+        });
+        module.global_variables.append(GlobalVariable {
+            name: Some("params".into()),
+            space: AddressSpace::Uniform,
+            binding: Some(ResourceBinding {
+                group: 0,
+                binding: 3,
+            }),
+            ty: params_ty,
+            init: None,
+        });
+
+        let mut func = Function::new("main");
+        func.body.push(Statement::Loop {
+            body: vec![Statement::Break],
+            continuing: vec![],
+            break_if: None,
+        });
+        module.entry_points.push(EntryPoint {
+            name: "main".into(),
+            workgroup_size: [16, 16, 1],
+            function: func,
+        });
+
+        let pattern = classify_entry_point(&module, 0).unwrap();
+        match pattern {
+            KernelPattern::MatMul { inputs, .. } => {
+                assert_eq!(inputs[0].name, "a"); // binding 0 sorted first
+                assert_eq!(inputs[1].name, "b"); // binding 1 sorted second
+            }
+            _ => panic!("expected MatMul pattern"),
+        }
+    }
+}

--- a/crates/nxpu-backend-onnx/src/lib.rs
+++ b/crates/nxpu-backend-onnx/src/lib.rs
@@ -1,0 +1,179 @@
+//! ONNX backend emitter for NxPU.
+//!
+//! Analyzes NxPU IR to recognize high-level tensor operations (MatMul,
+//! element-wise ops) and emits ONNX (`.onnx`) model files using protobuf
+//! serialization via prost.
+
+use nxpu_backend_core::{
+    Backend, BackendError, BackendOptions, BackendOutput, Diagnostic, DiagnosticLevel,
+    OutputContent, OutputFile,
+};
+use nxpu_ir::Module;
+use prost::Message;
+
+mod analyze;
+mod lower;
+pub mod proto;
+
+pub use analyze::{AnalysisError, ElementWiseOp, KernelPattern, TensorBinding};
+
+/// ONNX backend that compiles NxPU IR into `.onnx` model files.
+#[derive(Debug)]
+pub struct OnnxBackend;
+
+impl Backend for OnnxBackend {
+    fn name(&self) -> &str {
+        "ONNX"
+    }
+
+    fn targets(&self) -> &[&str] {
+        &["onnx"]
+    }
+
+    fn compile(
+        &self,
+        module: &Module,
+        _opts: &BackendOptions,
+    ) -> Result<BackendOutput, BackendError> {
+        if module.entry_points.is_empty() {
+            return Err(BackendError::Other("no entry points in module".into()));
+        }
+
+        let mut files = Vec::new();
+        let mut diagnostics = Vec::new();
+
+        for (i, ep) in module.entry_points.iter().enumerate() {
+            let pattern = analyze::classify_entry_point(module, i).map_err(|e| {
+                BackendError::Unsupported(format!("entry point '{}': {e}", ep.name))
+            })?;
+
+            diagnostics.push(Diagnostic {
+                level: DiagnosticLevel::Info,
+                message: format!(
+                    "entry point '{}': classified as {}",
+                    ep.name,
+                    pattern_summary(&pattern)
+                ),
+            });
+
+            let model = lower::build_model(&pattern, &ep.name);
+            let bytes = model.encode_to_vec();
+
+            let filename = if module.entry_points.len() == 1 {
+                "output.onnx".into()
+            } else {
+                format!("{}.onnx", ep.name)
+            };
+
+            files.push(OutputFile {
+                name: filename,
+                content: OutputContent::Binary(bytes),
+            });
+        }
+
+        Ok(BackendOutput { files, diagnostics })
+    }
+}
+
+fn pattern_summary(pattern: &KernelPattern) -> &'static str {
+    match pattern {
+        KernelPattern::MatMul { .. } => "MatMul",
+        KernelPattern::ElementWise { op, .. } => op.onnx_op_type(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nxpu_backend_core::BackendOptions;
+
+    #[test]
+    fn backend_metadata() {
+        let backend = OnnxBackend;
+        assert_eq!(backend.name(), "ONNX");
+        assert!(backend.targets().contains(&"onnx"));
+    }
+
+    #[test]
+    fn compile_empty_module_fails() {
+        let backend = OnnxBackend;
+        let module = Module::default();
+        let result = backend.compile(&module, &BackendOptions::default());
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn compile_matmul_wgsl() {
+        let source = std::fs::read_to_string(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../examples/matmul.wgsl"
+        ))
+        .unwrap();
+        let module = nxpu_parser::parse(&source).unwrap();
+
+        let backend = OnnxBackend;
+        let output = backend
+            .compile(&module, &BackendOptions::default())
+            .unwrap();
+
+        assert_eq!(output.files.len(), 1);
+        assert_eq!(output.files[0].name, "output.onnx");
+
+        let bytes = match &output.files[0].content {
+            OutputContent::Binary(b) => b,
+            _ => panic!("expected binary output"),
+        };
+
+        // Decode and verify the ONNX model.
+        let model = proto::ModelProto::decode(bytes.as_slice()).unwrap();
+        assert_eq!(model.ir_version, 7);
+        assert_eq!(model.producer_name, "nxpu");
+        assert_eq!(model.opset_import[0].version, 13);
+
+        let graph = model.graph.as_ref().unwrap();
+        assert_eq!(graph.node.len(), 1);
+        assert_eq!(graph.node[0].op_type, "MatMul");
+        assert_eq!(graph.input.len(), 2);
+        assert_eq!(graph.output.len(), 1);
+    }
+
+    #[test]
+    fn compile_vecadd_wgsl() {
+        let source = r#"
+@group(0) @binding(0) var<storage, read> a: array<f32>;
+@group(0) @binding(1) var<storage, read> b: array<f32>;
+@group(0) @binding(2) var<storage, read_write> c: array<f32>;
+
+struct Params { N: u32 }
+@group(0) @binding(3) var<uniform> params: Params;
+
+@compute @workgroup_size(256)
+fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
+  let idx = gid.x;
+  if (idx >= params.N) { return; }
+  c[idx] = a[idx] + b[idx];
+}
+"#;
+
+        let module = nxpu_parser::parse(source).unwrap();
+
+        let backend = OnnxBackend;
+        let output = backend
+            .compile(&module, &BackendOptions::default())
+            .unwrap();
+
+        assert_eq!(output.files.len(), 1);
+
+        let bytes = match &output.files[0].content {
+            OutputContent::Binary(b) => b,
+            _ => panic!("expected binary output"),
+        };
+
+        let model = proto::ModelProto::decode(bytes.as_slice()).unwrap();
+        let graph = model.graph.as_ref().unwrap();
+        assert_eq!(graph.node.len(), 1);
+        assert_eq!(graph.node[0].op_type, "Add");
+        assert_eq!(graph.input.len(), 2);
+        assert_eq!(graph.output.len(), 1);
+    }
+}

--- a/crates/nxpu-backend-onnx/src/lower.rs
+++ b/crates/nxpu-backend-onnx/src/lower.rs
@@ -1,0 +1,281 @@
+//! ONNX graph construction from classified kernel patterns.
+//!
+//! Converts a [`KernelPattern`] into an ONNX [`ModelProto`] with the
+//! appropriate graph topology (MatMul or element-wise op).
+
+use crate::analyze::{ElementWiseOp, KernelPattern, MatMulShape, TensorBinding};
+use crate::proto::*;
+
+/// Build an ONNX model from a classified kernel pattern.
+pub fn build_model(pattern: &KernelPattern, ep_name: &str) -> ModelProto {
+    let graph = match pattern {
+        KernelPattern::MatMul {
+            inputs,
+            output,
+            shape,
+        } => build_matmul_graph(inputs, output, shape, ep_name),
+        KernelPattern::ElementWise {
+            op,
+            inputs,
+            output,
+            dim_name,
+        } => build_elementwise_graph(*op, inputs, output, dim_name, ep_name),
+    };
+
+    ModelProto {
+        ir_version: 7,
+        producer_name: "nxpu".into(),
+        producer_version: env!("CARGO_PKG_VERSION").into(),
+        graph: Some(graph),
+        opset_import: vec![OperatorSetIdProto {
+            domain: String::new(),
+            version: 13,
+        }],
+    }
+}
+
+fn build_matmul_graph(
+    inputs: &[TensorBinding; 2],
+    output: &TensorBinding,
+    shape: &MatMulShape,
+    ep_name: &str,
+) -> GraphProto {
+    let a_name = &inputs[0].name;
+    let b_name = &inputs[1].name;
+    let c_name = &output.name;
+
+    GraphProto {
+        name: ep_name.into(),
+        node: vec![NodeProto {
+            input: vec![a_name.clone(), b_name.clone()],
+            output: vec![c_name.clone()],
+            name: "matmul_0".into(),
+            op_type: "MatMul".into(),
+            domain: String::new(),
+        }],
+        input: vec![
+            ValueInfoProto::tensor(
+                a_name,
+                inputs[0].elem_type,
+                vec![
+                    TensorShapeDimension::symbolic(&shape.m),
+                    TensorShapeDimension::symbolic(&shape.k),
+                ],
+            ),
+            ValueInfoProto::tensor(
+                b_name,
+                inputs[1].elem_type,
+                vec![
+                    TensorShapeDimension::symbolic(&shape.k),
+                    TensorShapeDimension::symbolic(&shape.n),
+                ],
+            ),
+        ],
+        output: vec![ValueInfoProto::tensor(
+            c_name,
+            output.elem_type,
+            vec![
+                TensorShapeDimension::symbolic(&shape.m),
+                TensorShapeDimension::symbolic(&shape.n),
+            ],
+        )],
+    }
+}
+
+fn build_elementwise_graph(
+    op: ElementWiseOp,
+    inputs: &[TensorBinding; 2],
+    output: &TensorBinding,
+    dim_name: &str,
+    ep_name: &str,
+) -> GraphProto {
+    let a_name = &inputs[0].name;
+    let b_name = &inputs[1].name;
+    let c_name = &output.name;
+
+    GraphProto {
+        name: ep_name.into(),
+        node: vec![NodeProto {
+            input: vec![a_name.clone(), b_name.clone()],
+            output: vec![c_name.clone()],
+            name: format!("{}_0", op.onnx_op_type().to_lowercase()),
+            op_type: op.onnx_op_type().into(),
+            domain: String::new(),
+        }],
+        input: vec![
+            ValueInfoProto::tensor(
+                a_name,
+                inputs[0].elem_type,
+                vec![TensorShapeDimension::symbolic(dim_name)],
+            ),
+            ValueInfoProto::tensor(
+                b_name,
+                inputs[1].elem_type,
+                vec![TensorShapeDimension::symbolic(dim_name)],
+            ),
+        ],
+        output: vec![ValueInfoProto::tensor(
+            c_name,
+            output.elem_type,
+            vec![TensorShapeDimension::symbolic(dim_name)],
+        )],
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::analyze::TensorRole;
+    use crate::proto::{data_type, tensor_shape_dimension, type_proto};
+    use nxpu_ir::Handle;
+
+    fn dummy_handle() -> Handle<nxpu_ir::GlobalVariable> {
+        // We just need any handle for testing; the arena provides them.
+        let mut arena = nxpu_ir::Arena::new();
+        arena.append(nxpu_ir::GlobalVariable {
+            name: None,
+            space: nxpu_ir::AddressSpace::Uniform,
+            binding: None,
+            ty: {
+                let mut types = nxpu_ir::UniqueArena::new();
+                types.insert(nxpu_ir::Type {
+                    name: None,
+                    inner: nxpu_ir::TypeInner::Scalar(nxpu_ir::Scalar::F32),
+                })
+            },
+            init: None,
+        })
+    }
+
+    fn make_tensor(name: &str, role: TensorRole) -> TensorBinding {
+        TensorBinding {
+            handle: dummy_handle(),
+            name: name.into(),
+            elem_type: data_type::FLOAT,
+            role,
+        }
+    }
+
+    #[test]
+    fn matmul_model_structure() {
+        let pattern = KernelPattern::MatMul {
+            inputs: [
+                make_tensor("A", TensorRole::Input),
+                make_tensor("B", TensorRole::Input),
+            ],
+            output: make_tensor("C", TensorRole::Output),
+            shape: MatMulShape {
+                m: "M".into(),
+                n: "N".into(),
+                k: "K".into(),
+            },
+        };
+
+        let model = build_model(&pattern, "matmul_kernel");
+
+        assert_eq!(model.ir_version, 7);
+        assert_eq!(model.producer_name, "nxpu");
+        assert_eq!(model.opset_import.len(), 1);
+        assert_eq!(model.opset_import[0].version, 13);
+
+        let graph = model.graph.as_ref().unwrap();
+        assert_eq!(graph.name, "matmul_kernel");
+        assert_eq!(graph.node.len(), 1);
+        assert_eq!(graph.node[0].op_type, "MatMul");
+        assert_eq!(graph.node[0].input, vec!["A", "B"]);
+        assert_eq!(graph.node[0].output, vec!["C"]);
+
+        assert_eq!(graph.input.len(), 2);
+        assert_eq!(graph.output.len(), 1);
+
+        // Verify A shape = [M, K].
+        let a_type = graph.input[0].r#type.as_ref().unwrap();
+        let a_tensor = match a_type.value.as_ref().unwrap() {
+            type_proto::Value::TensorType(t) => t,
+        };
+        assert_eq!(a_tensor.elem_type, data_type::FLOAT);
+        let a_dims = &a_tensor.shape.as_ref().unwrap().dim;
+        assert_eq!(a_dims.len(), 2);
+        assert_eq!(
+            a_dims[0].value,
+            Some(tensor_shape_dimension::Value::DimParam("M".into()))
+        );
+        assert_eq!(
+            a_dims[1].value,
+            Some(tensor_shape_dimension::Value::DimParam("K".into()))
+        );
+
+        // Verify C shape = [M, N].
+        let c_type = graph.output[0].r#type.as_ref().unwrap();
+        let c_tensor = match c_type.value.as_ref().unwrap() {
+            type_proto::Value::TensorType(t) => t,
+        };
+        let c_dims = &c_tensor.shape.as_ref().unwrap().dim;
+        assert_eq!(c_dims.len(), 2);
+        assert_eq!(
+            c_dims[0].value,
+            Some(tensor_shape_dimension::Value::DimParam("M".into()))
+        );
+        assert_eq!(
+            c_dims[1].value,
+            Some(tensor_shape_dimension::Value::DimParam("N".into()))
+        );
+    }
+
+    #[test]
+    fn elementwise_add_model_structure() {
+        let pattern = KernelPattern::ElementWise {
+            op: ElementWiseOp::Add,
+            inputs: [
+                make_tensor("x", TensorRole::Input),
+                make_tensor("y", TensorRole::Input),
+            ],
+            output: make_tensor("z", TensorRole::Output),
+            dim_name: "N".into(),
+        };
+
+        let model = build_model(&pattern, "vecadd");
+        let graph = model.graph.as_ref().unwrap();
+
+        assert_eq!(graph.node.len(), 1);
+        assert_eq!(graph.node[0].op_type, "Add");
+        assert_eq!(graph.node[0].name, "add_0");
+        assert_eq!(graph.node[0].input, vec!["x", "y"]);
+        assert_eq!(graph.node[0].output, vec!["z"]);
+
+        // All tensors are 1D with symbolic dim "N".
+        for vi in graph.input.iter().chain(graph.output.iter()) {
+            let tensor = match vi.r#type.as_ref().unwrap().value.as_ref().unwrap() {
+                type_proto::Value::TensorType(t) => t,
+            };
+            let dims = &tensor.shape.as_ref().unwrap().dim;
+            assert_eq!(dims.len(), 1);
+            assert_eq!(
+                dims[0].value,
+                Some(tensor_shape_dimension::Value::DimParam("N".into()))
+            );
+        }
+    }
+
+    #[test]
+    fn elementwise_ops() {
+        for (op, expected) in [
+            (ElementWiseOp::Sub, "Sub"),
+            (ElementWiseOp::Mul, "Mul"),
+            (ElementWiseOp::Div, "Div"),
+        ] {
+            let pattern = KernelPattern::ElementWise {
+                op,
+                inputs: [
+                    make_tensor("a", TensorRole::Input),
+                    make_tensor("b", TensorRole::Input),
+                ],
+                output: make_tensor("c", TensorRole::Output),
+                dim_name: "N".into(),
+            };
+            let model = build_model(&pattern, "test");
+            let graph = model.graph.as_ref().unwrap();
+            assert_eq!(graph.node[0].op_type, expected);
+        }
+    }
+}

--- a/crates/nxpu-backend-onnx/src/proto.rs
+++ b/crates/nxpu-backend-onnx/src/proto.rs
@@ -1,0 +1,242 @@
+//! ONNX protobuf types via prost derive.
+//!
+//! Hand-defined message types matching the ONNX IR specification (onnx.proto).
+//! Field tags correspond to the official ONNX protobuf field numbers.
+
+use prost::Message;
+
+/// ONNX data type constants from `TensorProto.DataType`.
+pub mod data_type {
+    pub const FLOAT: i32 = 1;
+    pub const FLOAT16: i32 = 10;
+    pub const INT32: i32 = 6;
+    pub const UINT32: i32 = 12;
+    pub const BOOL: i32 = 9;
+}
+
+/// Top-level ONNX model container.
+#[derive(Clone, PartialEq, Message)]
+pub struct ModelProto {
+    #[prost(int64, tag = "1")]
+    pub ir_version: i64,
+    #[prost(string, tag = "2")]
+    pub producer_name: String,
+    #[prost(string, tag = "3")]
+    pub producer_version: String,
+    #[prost(message, optional, tag = "7")]
+    pub graph: Option<GraphProto>,
+    #[prost(message, repeated, tag = "8")]
+    pub opset_import: Vec<OperatorSetIdProto>,
+}
+
+/// Operator set version declaration.
+#[derive(Clone, PartialEq, Message)]
+pub struct OperatorSetIdProto {
+    #[prost(string, tag = "1")]
+    pub domain: String,
+    #[prost(int64, tag = "2")]
+    pub version: i64,
+}
+
+/// A computation graph.
+#[derive(Clone, PartialEq, Message)]
+pub struct GraphProto {
+    #[prost(message, repeated, tag = "1")]
+    pub node: Vec<NodeProto>,
+    #[prost(string, tag = "2")]
+    pub name: String,
+    #[prost(message, repeated, tag = "11")]
+    pub input: Vec<ValueInfoProto>,
+    #[prost(message, repeated, tag = "12")]
+    pub output: Vec<ValueInfoProto>,
+}
+
+/// A single operator invocation.
+#[derive(Clone, PartialEq, Message)]
+pub struct NodeProto {
+    #[prost(string, repeated, tag = "1")]
+    pub input: Vec<String>,
+    #[prost(string, repeated, tag = "2")]
+    pub output: Vec<String>,
+    #[prost(string, tag = "3")]
+    pub name: String,
+    #[prost(string, tag = "4")]
+    pub op_type: String,
+    #[prost(string, tag = "7")]
+    pub domain: String,
+}
+
+/// Typed tensor name declaration.
+#[derive(Clone, PartialEq, Message)]
+pub struct ValueInfoProto {
+    #[prost(string, tag = "1")]
+    pub name: String,
+    #[prost(message, optional, tag = "2")]
+    pub r#type: Option<TypeProto>,
+}
+
+impl ValueInfoProto {
+    /// Create a tensor value info with symbolic/fixed dimensions.
+    pub fn tensor(
+        name: impl Into<String>,
+        elem_type: i32,
+        dims: Vec<TensorShapeDimension>,
+    ) -> Self {
+        Self {
+            name: name.into(),
+            r#type: Some(TypeProto {
+                value: Some(type_proto::Value::TensorType(TensorTypeProto {
+                    elem_type,
+                    shape: Some(TensorShapeProto { dim: dims }),
+                })),
+            }),
+        }
+    }
+}
+
+/// Type of a value (currently only tensor types).
+#[derive(Clone, PartialEq, Message)]
+pub struct TypeProto {
+    #[prost(oneof = "type_proto::Value", tags = "1")]
+    pub value: Option<type_proto::Value>,
+}
+
+pub mod type_proto {
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    pub enum Value {
+        #[prost(message, tag = "1")]
+        TensorType(super::TensorTypeProto),
+    }
+}
+
+/// Tensor type: element data type + shape.
+#[derive(Clone, PartialEq, Message)]
+pub struct TensorTypeProto {
+    #[prost(int32, tag = "1")]
+    pub elem_type: i32,
+    #[prost(message, optional, tag = "2")]
+    pub shape: Option<TensorShapeProto>,
+}
+
+/// Tensor shape: a list of dimensions.
+#[derive(Clone, PartialEq, Message)]
+pub struct TensorShapeProto {
+    #[prost(message, repeated, tag = "1")]
+    pub dim: Vec<TensorShapeDimension>,
+}
+
+/// A single dimension (either a fixed value or a symbolic parameter).
+#[derive(Clone, PartialEq, Message)]
+pub struct TensorShapeDimension {
+    #[prost(oneof = "tensor_shape_dimension::Value", tags = "1, 2")]
+    pub value: Option<tensor_shape_dimension::Value>,
+}
+
+pub mod tensor_shape_dimension {
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    pub enum Value {
+        #[prost(int64, tag = "1")]
+        DimValue(i64),
+        #[prost(string, tag = "2")]
+        DimParam(String),
+    }
+}
+
+impl TensorShapeDimension {
+    /// Create a symbolic (named) dimension.
+    pub fn symbolic(name: impl Into<String>) -> Self {
+        Self {
+            value: Some(tensor_shape_dimension::Value::DimParam(name.into())),
+        }
+    }
+
+    /// Create a fixed-size dimension.
+    pub fn fixed(size: i64) -> Self {
+        Self {
+            value: Some(tensor_shape_dimension::Value::DimValue(size)),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use prost::Message;
+
+    #[test]
+    fn model_roundtrip() {
+        let model = ModelProto {
+            ir_version: 7,
+            producer_name: "nxpu".into(),
+            producer_version: "0.1.0".into(),
+            graph: Some(GraphProto {
+                name: "test".into(),
+                node: vec![NodeProto {
+                    input: vec!["A".into(), "B".into()],
+                    output: vec!["C".into()],
+                    name: "matmul_0".into(),
+                    op_type: "MatMul".into(),
+                    domain: String::new(),
+                }],
+                input: vec![ValueInfoProto::tensor(
+                    "A",
+                    data_type::FLOAT,
+                    vec![
+                        TensorShapeDimension::symbolic("M"),
+                        TensorShapeDimension::symbolic("K"),
+                    ],
+                )],
+                output: vec![ValueInfoProto::tensor(
+                    "C",
+                    data_type::FLOAT,
+                    vec![
+                        TensorShapeDimension::symbolic("M"),
+                        TensorShapeDimension::symbolic("N"),
+                    ],
+                )],
+            }),
+            opset_import: vec![OperatorSetIdProto {
+                domain: String::new(),
+                version: 13,
+            }],
+        };
+
+        let bytes = model.encode_to_vec();
+        let decoded = ModelProto::decode(bytes.as_slice()).unwrap();
+        assert_eq!(model, decoded);
+    }
+
+    #[test]
+    fn tensor_shape_symbolic() {
+        let dim = TensorShapeDimension::symbolic("N");
+        assert_eq!(
+            dim.value,
+            Some(tensor_shape_dimension::Value::DimParam("N".into()))
+        );
+    }
+
+    #[test]
+    fn tensor_shape_fixed() {
+        let dim = TensorShapeDimension::fixed(128);
+        assert_eq!(
+            dim.value,
+            Some(tensor_shape_dimension::Value::DimValue(128))
+        );
+    }
+
+    #[test]
+    fn value_info_tensor_helper() {
+        let vi = ValueInfoProto::tensor(
+            "X",
+            data_type::FLOAT,
+            vec![TensorShapeDimension::symbolic("batch")],
+        );
+        assert_eq!(vi.name, "X");
+        let ty = vi.r#type.unwrap();
+        let tensor = match ty.value.unwrap() {
+            type_proto::Value::TensorType(t) => t,
+        };
+        assert_eq!(tensor.elem_type, data_type::FLOAT);
+        assert_eq!(tensor.shape.unwrap().dim.len(), 1);
+    }
+}

--- a/crates/nxpu-cli/Cargo.toml
+++ b/crates/nxpu-cli/Cargo.toml
@@ -14,6 +14,7 @@ nxpu-parser = { path = "../nxpu-parser" }
 nxpu-ir = { path = "../nxpu-ir" }
 nxpu-opt = { path = "../nxpu-opt" }
 nxpu-backend-core = { path = "../nxpu-backend-core" }
+nxpu-backend-onnx = { path = "../nxpu-backend-onnx" }
 clap = { version = "4", features = ["derive"] }
 miette = { version = "7", features = ["fancy"] }
 thiserror = "2"

--- a/crates/nxpu-cli/src/main.rs
+++ b/crates/nxpu-cli/src/main.rs
@@ -83,7 +83,8 @@ fn run() -> miette::Result<()> {
     }
 
     // 6. Backend dispatch.
-    let registry = BackendRegistry::with_builtins();
+    let mut registry = BackendRegistry::with_builtins();
+    registry.register(Box::new(nxpu_backend_onnx::OnnxBackend));
     let backend = registry.find(&cli.target).ok_or_else(|| {
         let available = registry.list_targets().join(", ");
         miette::miette!("unknown target '{}' (available: {})", cli.target, available)


### PR DESCRIPTION
## Summary
- Add `nxpu-backend-onnx` crate that emits ONNX (`.onnx`) models from NxPU IR, enabling 6+ NPU targets (Samsung, Intel, AMD, Qualcomm, etc.)
- Implements pattern recognition to bridge the semantic gap between NxPU-IR (loops, array indexing) and ONNX (high-level tensor ops): **MatMul** (loop + accumulation) and **ElementWise** (Add/Sub/Mul/Div)
- Uses `prost` for protobuf serialization with hand-defined ONNX message types (no build.rs, no .proto files), targeting ONNX opset 13, IR version 7
- Registers `OnnxBackend` in CLI: `nxpu input.wgsl --target onnx --output model.onnx`

## Test plan
- [x] `cargo check --workspace` — compiles cleanly
- [x] `cargo test -p nxpu-backend-onnx` — 17 unit + integration tests pass (proto roundtrip, pattern classification, graph construction, matmul.wgsl e2e, vecadd WGSL e2e)
- [x] `cargo test --workspace` — all 89 tests pass (no regressions)
- [x] `cargo clippy --workspace` — no warnings
- [x] `cargo fmt --check` — clean
- [x] `cargo run -- examples/matmul.wgsl --target onnx --output /tmp/matmul.onnx` — produces valid .onnx file

🤖 Generated with [Claude Code](https://claude.com/claude-code)