### PR TITLE
Implement Samsung Exynos NPU backend

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     "crates/nxpu-backend-tflite",
     "crates/nxpu-backend-coreml",
     "crates/nxpu-backend-stablehlo",
+    "crates/nxpu-backend-samsung",
     "crates/nxpu-cli",
 ]
 

--- a/crates/nxpu-backend-samsung/Cargo.toml
+++ b/crates/nxpu-backend-samsung/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "nxpu-backend-samsung"
+description = "Samsung Exynos NPU backend for NxPU (via ONNX)"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+nxpu-ir = { path = "../nxpu-ir" }
+nxpu-backend-core = { path = "../nxpu-backend-core" }
+nxpu-backend-onnx = { path = "../nxpu-backend-onnx" }
+
+[dev-dependencies]
+nxpu-parser = { path = "../nxpu-parser" }

--- a/crates/nxpu-backend-samsung/src/lib.rs
+++ b/crates/nxpu-backend-samsung/src/lib.rs
@@ -1,0 +1,68 @@
+//! Samsung Exynos NPU backend for NxPU.
+//!
+//! Thin vendor wrapper that delegates compilation to the ONNX backend
+//! and emits `.onnx` files suitable for the Samsung Exynos NPU toolchain.
+
+use nxpu_backend_core::{
+    Backend, BackendError, BackendOptions, BackendOutput, Diagnostic, DiagnosticLevel,
+};
+use nxpu_backend_onnx::OnnxBackend;
+use nxpu_ir::Module;
+
+/// Samsung Exynos NPU backend (delegates to ONNX).
+#[derive(Debug)]
+pub struct SamsungBackend;
+
+impl Backend for SamsungBackend {
+    fn name(&self) -> &str {
+        "Samsung Exynos NPU"
+    }
+
+    fn targets(&self) -> &[&str] {
+        &["samsung", "exynos"]
+    }
+
+    fn compile(
+        &self,
+        module: &Module,
+        opts: &BackendOptions,
+    ) -> Result<BackendOutput, BackendError> {
+        let mut output = OnnxBackend.compile(module, opts)?;
+        output.diagnostics.push(Diagnostic {
+            level: DiagnosticLevel::Info,
+            message: "To compile for Exynos NPU: one-import-onnx output.onnx".into(),
+        });
+        Ok(output)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nxpu_backend_core::{BackendOptions, OutputContent};
+
+    #[test]
+    fn backend_metadata() {
+        let backend = SamsungBackend;
+        assert_eq!(backend.name(), "Samsung Exynos NPU");
+        assert!(backend.targets().contains(&"samsung"));
+        assert!(backend.targets().contains(&"exynos"));
+    }
+
+    #[test]
+    fn compile_matmul_delegates() {
+        let source = std::fs::read_to_string(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../examples/matmul.wgsl"
+        ))
+        .unwrap();
+        let module = nxpu_parser::parse(&source).unwrap();
+
+        let output = SamsungBackend
+            .compile(&module, &BackendOptions::default())
+            .unwrap();
+        assert_eq!(output.files.len(), 1);
+        assert_eq!(output.files[0].name, "output.onnx");
+        assert!(matches!(output.files[0].content, OutputContent::Binary(_)));
+    }
+}

--- a/crates/nxpu-cli/Cargo.toml
+++ b/crates/nxpu-cli/Cargo.toml
@@ -18,6 +18,7 @@ nxpu-backend-onnx = { path = "../nxpu-backend-onnx" }
 nxpu-backend-tflite = { path = "../nxpu-backend-tflite" }
 nxpu-backend-coreml = { path = "../nxpu-backend-coreml" }
 nxpu-backend-stablehlo = { path = "../nxpu-backend-stablehlo" }
+nxpu-backend-samsung = { path = "../nxpu-backend-samsung" }
 clap = { version = "4", features = ["derive"] }
 miette = { version = "7", features = ["fancy"] }
 thiserror = "2"

--- a/crates/nxpu-cli/src/main.rs
+++ b/crates/nxpu-cli/src/main.rs
@@ -88,6 +88,7 @@ fn run() -> miette::Result<()> {
     registry.register(Box::new(nxpu_backend_tflite::TfLiteBackend));
     registry.register(Box::new(nxpu_backend_coreml::CoreMlBackend));
     registry.register(Box::new(nxpu_backend_stablehlo::StableHloBackend));
+    registry.register(Box::new(nxpu_backend_samsung::SamsungBackend));
     let backend = registry.find(&cli.target).ok_or_else(|| {
         let available = registry.list_targets().join(", ");
         miette::miette!("unknown target '{}' (available: {})", cli.target, available)


### PR DESCRIPTION
## Summary
- Adds `nxpu-backend-samsung` crate — thin vendor wrapper delegating to ONNX backend
- Emits `.onnx` files suitable for the Samsung ONE (Exynos NPU) toolchain
- Registers `samsung` and `exynos` targets in CLI

## Test plan
- [x] `cargo test -p nxpu-backend-samsung` — 2 tests pass
- [x] CLI registers Samsung backend target

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)