### PR TITLE
Implement MediaTek APU backend

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
     "crates/nxpu-backend-coreml",
     "crates/nxpu-backend-stablehlo",
     "crates/nxpu-backend-samsung",
+    "crates/nxpu-backend-mediatek",
     "crates/nxpu-cli",
 ]
 

--- a/crates/nxpu-backend-mediatek/Cargo.toml
+++ b/crates/nxpu-backend-mediatek/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "nxpu-backend-mediatek"
+description = "MediaTek APU backend for NxPU (via TFLite)"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+nxpu-ir = { path = "../nxpu-ir" }
+nxpu-backend-core = { path = "../nxpu-backend-core" }
+nxpu-backend-tflite = { path = "../nxpu-backend-tflite" }
+
+[dev-dependencies]
+nxpu-parser = { path = "../nxpu-parser" }

--- a/crates/nxpu-backend-mediatek/src/lib.rs
+++ b/crates/nxpu-backend-mediatek/src/lib.rs
@@ -1,0 +1,68 @@
+//! MediaTek APU backend for NxPU.
+//!
+//! Thin vendor wrapper that delegates compilation to the TFLite backend
+//! and emits `.tflite` files suitable for the MediaTek NeuroPilot toolchain.
+
+use nxpu_backend_core::{
+    Backend, BackendError, BackendOptions, BackendOutput, Diagnostic, DiagnosticLevel,
+};
+use nxpu_backend_tflite::TfLiteBackend;
+use nxpu_ir::Module;
+
+/// MediaTek APU backend (delegates to TFLite).
+#[derive(Debug)]
+pub struct MediaTekBackend;
+
+impl Backend for MediaTekBackend {
+    fn name(&self) -> &str {
+        "MediaTek APU"
+    }
+
+    fn targets(&self) -> &[&str] {
+        &["mediatek", "neuropilot"]
+    }
+
+    fn compile(
+        &self,
+        module: &Module,
+        opts: &BackendOptions,
+    ) -> Result<BackendOutput, BackendError> {
+        let mut output = TfLiteBackend.compile(module, opts)?;
+        output.diagnostics.push(Diagnostic {
+            level: DiagnosticLevel::Info,
+            message: "To compile for MediaTek APU: ncc-tflite output.tflite".into(),
+        });
+        Ok(output)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nxpu_backend_core::{BackendOptions, OutputContent};
+
+    #[test]
+    fn backend_metadata() {
+        let backend = MediaTekBackend;
+        assert_eq!(backend.name(), "MediaTek APU");
+        assert!(backend.targets().contains(&"mediatek"));
+        assert!(backend.targets().contains(&"neuropilot"));
+    }
+
+    #[test]
+    fn compile_matmul_delegates() {
+        let source = std::fs::read_to_string(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../examples/matmul.wgsl"
+        ))
+        .unwrap();
+        let module = nxpu_parser::parse(&source).unwrap();
+
+        let output = MediaTekBackend
+            .compile(&module, &BackendOptions::default())
+            .unwrap();
+        assert_eq!(output.files.len(), 1);
+        assert_eq!(output.files[0].name, "output.tflite");
+        assert!(matches!(output.files[0].content, OutputContent::Binary(_)));
+    }
+}

--- a/crates/nxpu-cli/Cargo.toml
+++ b/crates/nxpu-cli/Cargo.toml
@@ -19,6 +19,7 @@ nxpu-backend-tflite = { path = "../nxpu-backend-tflite" }
 nxpu-backend-coreml = { path = "../nxpu-backend-coreml" }
 nxpu-backend-stablehlo = { path = "../nxpu-backend-stablehlo" }
 nxpu-backend-samsung = { path = "../nxpu-backend-samsung" }
+nxpu-backend-mediatek = { path = "../nxpu-backend-mediatek" }
 clap = { version = "4", features = ["derive"] }
 miette = { version = "7", features = ["fancy"] }
 thiserror = "2"

--- a/crates/nxpu-cli/src/main.rs
+++ b/crates/nxpu-cli/src/main.rs
@@ -89,6 +89,7 @@ fn run() -> miette::Result<()> {
     registry.register(Box::new(nxpu_backend_coreml::CoreMlBackend));
     registry.register(Box::new(nxpu_backend_stablehlo::StableHloBackend));
     registry.register(Box::new(nxpu_backend_samsung::SamsungBackend));
+    registry.register(Box::new(nxpu_backend_mediatek::MediaTekBackend));
     let backend = registry.find(&cli.target).ok_or_else(|| {
         let available = registry.list_targets().join(", ");
         miette::miette!("unknown target '{}' (available: {})", cli.target, available)


### PR DESCRIPTION
## Summary
- Adds `nxpu-backend-mediatek` crate — thin vendor wrapper delegating to TFLite backend
- Emits `.tflite` files suitable for the MediaTek NeuroPilot toolchain
- Registers `mediatek` and `neuropilot` targets in CLI

## Test plan
- [x] `cargo test -p nxpu-backend-mediatek` — 2 tests pass
- [x] CLI registers MediaTek backend target

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)