### PR TITLE
Implement AMD XDNA NPU backend

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
     "crates/nxpu-backend-samsung",
     "crates/nxpu-backend-mediatek",
     "crates/nxpu-backend-intel",
+    "crates/nxpu-backend-amd",
     "crates/nxpu-cli",
 ]
 

--- a/crates/nxpu-backend-amd/Cargo.toml
+++ b/crates/nxpu-backend-amd/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "nxpu-backend-amd"
+description = "AMD XDNA NPU backend for NxPU (via ONNX)"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+nxpu-ir = { path = "../nxpu-ir" }
+nxpu-backend-core = { path = "../nxpu-backend-core" }
+nxpu-backend-onnx = { path = "../nxpu-backend-onnx" }
+
+[dev-dependencies]
+nxpu-parser = { path = "../nxpu-parser" }

--- a/crates/nxpu-backend-amd/src/lib.rs
+++ b/crates/nxpu-backend-amd/src/lib.rs
@@ -1,0 +1,68 @@
+//! AMD XDNA NPU backend for NxPU.
+//!
+//! Thin vendor wrapper that delegates compilation to the ONNX backend
+//! and emits `.onnx` files suitable for AMD XDNA / Vitis AI.
+
+use nxpu_backend_core::{
+    Backend, BackendError, BackendOptions, BackendOutput, Diagnostic, DiagnosticLevel,
+};
+use nxpu_backend_onnx::OnnxBackend;
+use nxpu_ir::Module;
+
+/// AMD XDNA NPU backend (delegates to ONNX).
+#[derive(Debug)]
+pub struct AmdBackend;
+
+impl Backend for AmdBackend {
+    fn name(&self) -> &str {
+        "AMD XDNA NPU"
+    }
+
+    fn targets(&self) -> &[&str] {
+        &["amd-xdna", "amd-npu"]
+    }
+
+    fn compile(
+        &self,
+        module: &Module,
+        opts: &BackendOptions,
+    ) -> Result<BackendOutput, BackendError> {
+        let mut output = OnnxBackend.compile(module, opts)?;
+        output.diagnostics.push(Diagnostic {
+            level: DiagnosticLevel::Info,
+            message: "To compile for XDNA: use Vitis AI EP with ONNX Runtime".into(),
+        });
+        Ok(output)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nxpu_backend_core::{BackendOptions, OutputContent};
+
+    #[test]
+    fn backend_metadata() {
+        let backend = AmdBackend;
+        assert_eq!(backend.name(), "AMD XDNA NPU");
+        assert!(backend.targets().contains(&"amd-xdna"));
+        assert!(backend.targets().contains(&"amd-npu"));
+    }
+
+    #[test]
+    fn compile_matmul_delegates() {
+        let source = std::fs::read_to_string(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../examples/matmul.wgsl"
+        ))
+        .unwrap();
+        let module = nxpu_parser::parse(&source).unwrap();
+
+        let output = AmdBackend
+            .compile(&module, &BackendOptions::default())
+            .unwrap();
+        assert_eq!(output.files.len(), 1);
+        assert_eq!(output.files[0].name, "output.onnx");
+        assert!(matches!(output.files[0].content, OutputContent::Binary(_)));
+    }
+}

--- a/crates/nxpu-cli/Cargo.toml
+++ b/crates/nxpu-cli/Cargo.toml
@@ -21,6 +21,7 @@ nxpu-backend-stablehlo = { path = "../nxpu-backend-stablehlo" }
 nxpu-backend-samsung = { path = "../nxpu-backend-samsung" }
 nxpu-backend-mediatek = { path = "../nxpu-backend-mediatek" }
 nxpu-backend-intel = { path = "../nxpu-backend-intel" }
+nxpu-backend-amd = { path = "../nxpu-backend-amd" }
 clap = { version = "4", features = ["derive"] }
 miette = { version = "7", features = ["fancy"] }
 thiserror = "2"

--- a/crates/nxpu-cli/src/main.rs
+++ b/crates/nxpu-cli/src/main.rs
@@ -91,6 +91,7 @@ fn run() -> miette::Result<()> {
     registry.register(Box::new(nxpu_backend_samsung::SamsungBackend));
     registry.register(Box::new(nxpu_backend_mediatek::MediaTekBackend));
     registry.register(Box::new(nxpu_backend_intel::IntelBackend));
+    registry.register(Box::new(nxpu_backend_amd::AmdBackend));
     let backend = registry.find(&cli.target).ok_or_else(|| {
         let available = registry.list_targets().join(", ");
         miette::miette!("unknown target '{}' (available: {})", cli.target, available)


### PR DESCRIPTION
## Summary
- Adds `nxpu-backend-amd` crate — thin vendor wrapper delegating to ONNX backend
- Emits `.onnx` files suitable for the AMD Vitis AI / XDNA toolchain
- Registers `amd-xdna` and `amd-npu` targets in CLI

## Test plan
- [x] `cargo test -p nxpu-backend-amd` — 2 tests pass
- [x] CLI registers AMD backend target

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)