### PR TITLE
Implement Arm Ethos NPU backend

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ members = [
     "crates/nxpu-backend-intel",
     "crates/nxpu-backend-amd",
     "crates/nxpu-backend-qualcomm",
+    "crates/nxpu-backend-arm-ethos",
     "crates/nxpu-cli",
 ]
 

--- a/crates/nxpu-backend-arm-ethos/Cargo.toml
+++ b/crates/nxpu-backend-arm-ethos/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "nxpu-backend-arm-ethos"
+description = "Arm Ethos NPU backend for NxPU (via TFLite)"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+nxpu-ir = { path = "../nxpu-ir" }
+nxpu-backend-core = { path = "../nxpu-backend-core" }
+nxpu-backend-tflite = { path = "../nxpu-backend-tflite" }
+
+[dev-dependencies]
+nxpu-parser = { path = "../nxpu-parser" }

--- a/crates/nxpu-backend-arm-ethos/src/lib.rs
+++ b/crates/nxpu-backend-arm-ethos/src/lib.rs
@@ -1,0 +1,68 @@
+//! Arm Ethos NPU backend for NxPU.
+//!
+//! Thin vendor wrapper that delegates compilation to the TFLite backend
+//! and emits `.tflite` files suitable for the Arm Ethos-U / Vela toolchain.
+
+use nxpu_backend_core::{
+    Backend, BackendError, BackendOptions, BackendOutput, Diagnostic, DiagnosticLevel,
+};
+use nxpu_backend_tflite::TfLiteBackend;
+use nxpu_ir::Module;
+
+/// Arm Ethos NPU backend (delegates to TFLite).
+#[derive(Debug)]
+pub struct ArmEthosBackend;
+
+impl Backend for ArmEthosBackend {
+    fn name(&self) -> &str {
+        "Arm Ethos NPU"
+    }
+
+    fn targets(&self) -> &[&str] {
+        &["arm-ethos", "ethos-u"]
+    }
+
+    fn compile(
+        &self,
+        module: &Module,
+        opts: &BackendOptions,
+    ) -> Result<BackendOutput, BackendError> {
+        let mut output = TfLiteBackend.compile(module, opts)?;
+        output.diagnostics.push(Diagnostic {
+            level: DiagnosticLevel::Info,
+            message: "To compile for Ethos NPU: vela output.tflite".into(),
+        });
+        Ok(output)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nxpu_backend_core::{BackendOptions, OutputContent};
+
+    #[test]
+    fn backend_metadata() {
+        let backend = ArmEthosBackend;
+        assert_eq!(backend.name(), "Arm Ethos NPU");
+        assert!(backend.targets().contains(&"arm-ethos"));
+        assert!(backend.targets().contains(&"ethos-u"));
+    }
+
+    #[test]
+    fn compile_matmul_delegates() {
+        let source = std::fs::read_to_string(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../examples/matmul.wgsl"
+        ))
+        .unwrap();
+        let module = nxpu_parser::parse(&source).unwrap();
+
+        let output = ArmEthosBackend
+            .compile(&module, &BackendOptions::default())
+            .unwrap();
+        assert_eq!(output.files.len(), 1);
+        assert_eq!(output.files[0].name, "output.tflite");
+        assert!(matches!(output.files[0].content, OutputContent::Binary(_)));
+    }
+}

--- a/crates/nxpu-cli/Cargo.toml
+++ b/crates/nxpu-cli/Cargo.toml
@@ -23,6 +23,7 @@ nxpu-backend-mediatek = { path = "../nxpu-backend-mediatek" }
 nxpu-backend-intel = { path = "../nxpu-backend-intel" }
 nxpu-backend-amd = { path = "../nxpu-backend-amd" }
 nxpu-backend-qualcomm = { path = "../nxpu-backend-qualcomm" }
+nxpu-backend-arm-ethos = { path = "../nxpu-backend-arm-ethos" }
 clap = { version = "4", features = ["derive"] }
 miette = { version = "7", features = ["fancy"] }
 thiserror = "2"

--- a/crates/nxpu-cli/src/main.rs
+++ b/crates/nxpu-cli/src/main.rs
@@ -93,6 +93,7 @@ fn run() -> miette::Result<()> {
     registry.register(Box::new(nxpu_backend_intel::IntelBackend));
     registry.register(Box::new(nxpu_backend_amd::AmdBackend));
     registry.register(Box::new(nxpu_backend_qualcomm::QualcommBackend));
+    registry.register(Box::new(nxpu_backend_arm_ethos::ArmEthosBackend));
     let backend = registry.find(&cli.target).ok_or_else(|| {
         let available = registry.list_targets().join(", ");
         miette::miette!("unknown target '{}' (available: {})", cli.target, available)


### PR DESCRIPTION
## Summary
- Adds `nxpu-backend-arm-ethos` crate — thin vendor wrapper delegating to TFLite backend
- Emits `.tflite` files suitable for the Arm Vela (Ethos-U) toolchain
- Registers `arm-ethos` and `ethos-u` targets in CLI

## Test plan
- [x] `cargo test -p nxpu-backend-arm-ethos` — 2 tests pass
- [x] CLI registers Arm Ethos backend target

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)