### PR TITLE
Implement quantization passes and E2E integration tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ members = [
     "crates/nxpu-backend-ceva",
     "crates/nxpu-backend-rockchip",
     "crates/nxpu-cli",
+    "crates/nxpu-e2e-tests",
 ]
 
 [workspace.package]

--- a/crates/nxpu-backend-amd/src/lib.rs
+++ b/crates/nxpu-backend-amd/src/lib.rs
@@ -4,7 +4,7 @@
 //! and emits `.onnx` files suitable for AMD XDNA / Vitis AI.
 
 use nxpu_backend_core::{
-    Backend, BackendError, BackendOptions, BackendOutput, Diagnostic, DiagnosticLevel,
+    Backend, BackendError, BackendOptions, BackendOutput, Diagnostic, DiagnosticLevel, Precision,
 };
 use nxpu_backend_onnx::OnnxBackend;
 use nxpu_ir::Module;
@@ -20,6 +20,10 @@ impl Backend for AmdBackend {
 
     fn targets(&self) -> &[&str] {
         &["amd-xdna", "amd-npu"]
+    }
+
+    fn preferred_precision(&self) -> Precision {
+        Precision::Int8
     }
 
     fn compile(

--- a/crates/nxpu-backend-arm-ethos/src/lib.rs
+++ b/crates/nxpu-backend-arm-ethos/src/lib.rs
@@ -4,7 +4,7 @@
 //! and emits `.tflite` files suitable for the Arm Ethos-U / Vela toolchain.
 
 use nxpu_backend_core::{
-    Backend, BackendError, BackendOptions, BackendOutput, Diagnostic, DiagnosticLevel,
+    Backend, BackendError, BackendOptions, BackendOutput, Diagnostic, DiagnosticLevel, Precision,
 };
 use nxpu_backend_tflite::TfLiteBackend;
 use nxpu_ir::Module;
@@ -20,6 +20,10 @@ impl Backend for ArmEthosBackend {
 
     fn targets(&self) -> &[&str] {
         &["arm-ethos", "ethos-u"]
+    }
+
+    fn preferred_precision(&self) -> Precision {
+        Precision::Int8
     }
 
     fn compile(

--- a/crates/nxpu-backend-coreml/src/lib.rs
+++ b/crates/nxpu-backend-coreml/src/lib.rs
@@ -5,7 +5,7 @@
 
 use nxpu_backend_core::{
     Backend, BackendError, BackendOptions, BackendOutput, Diagnostic, DiagnosticLevel,
-    OutputContent, OutputFile,
+    OutputContent, OutputFile, Precision,
 };
 use nxpu_backend_onnx::analyze;
 use nxpu_ir::Module;
@@ -25,6 +25,10 @@ impl Backend for CoreMlBackend {
 
     fn targets(&self) -> &[&str] {
         &["coreml", "apple-ane"]
+    }
+
+    fn preferred_precision(&self) -> Precision {
+        Precision::F16
     }
 
     fn compile(

--- a/crates/nxpu-backend-coreml/src/lower.rs
+++ b/crates/nxpu-backend-coreml/src/lower.rs
@@ -70,6 +70,8 @@ fn onnx_to_coreml_type(onnx_dt: i32) -> ArrayDataType {
     match onnx_dt {
         data_type::FLOAT16 => ArrayDataType::Float16,
         data_type::INT32 => ArrayDataType::Int32,
+        // INT8 not natively supported on ANE — fall back to FP16.
+        data_type::INT8 => ArrayDataType::Float16,
         // ANE operates at FP16; promote FP32 to FP16.
         _ => ArrayDataType::Float16,
     }

--- a/crates/nxpu-backend-intel/src/lib.rs
+++ b/crates/nxpu-backend-intel/src/lib.rs
@@ -4,7 +4,7 @@
 //! and emits `.onnx` files suitable for OpenVINO / Intel NPU.
 
 use nxpu_backend_core::{
-    Backend, BackendError, BackendOptions, BackendOutput, Diagnostic, DiagnosticLevel,
+    Backend, BackendError, BackendOptions, BackendOutput, Diagnostic, DiagnosticLevel, Precision,
 };
 use nxpu_backend_onnx::OnnxBackend;
 use nxpu_ir::Module;
@@ -20,6 +20,10 @@ impl Backend for IntelBackend {
 
     fn targets(&self) -> &[&str] {
         &["intel-npu", "openvino"]
+    }
+
+    fn preferred_precision(&self) -> Precision {
+        Precision::F16
     }
 
     fn compile(

--- a/crates/nxpu-backend-onnx/src/analyze.rs
+++ b/crates/nxpu-backend-onnx/src/analyze.rs
@@ -219,8 +219,11 @@ fn scalar_to_onnx_data_type(scalar: &Scalar) -> i32 {
     match (scalar.kind, scalar.width) {
         (ScalarKind::Float, 4) => data_type::FLOAT,
         (ScalarKind::Float, 2) => data_type::FLOAT16,
+        (ScalarKind::BFloat, 2) => data_type::BFLOAT16,
         (ScalarKind::Sint, 4) => data_type::INT32,
+        (ScalarKind::Sint, 1) => data_type::INT8,
         (ScalarKind::Uint, 4) => data_type::UINT32,
+        (ScalarKind::Uint, 1) => data_type::UINT8,
         (ScalarKind::Bool, _) => data_type::BOOL,
         _ => data_type::FLOAT,
     }

--- a/crates/nxpu-backend-onnx/src/proto.rs
+++ b/crates/nxpu-backend-onnx/src/proto.rs
@@ -8,10 +8,13 @@ use prost::Message;
 /// ONNX data type constants from `TensorProto.DataType`.
 pub mod data_type {
     pub const FLOAT: i32 = 1;
+    pub const UINT8: i32 = 2;
+    pub const INT8: i32 = 3;
     pub const FLOAT16: i32 = 10;
     pub const INT32: i32 = 6;
     pub const UINT32: i32 = 12;
     pub const BOOL: i32 = 9;
+    pub const BFLOAT16: i32 = 16;
 }
 
 /// Top-level ONNX model container.

--- a/crates/nxpu-backend-qualcomm/src/lib.rs
+++ b/crates/nxpu-backend-qualcomm/src/lib.rs
@@ -4,7 +4,7 @@
 //! and emits `.onnx` files suitable for the Qualcomm QNN toolchain.
 
 use nxpu_backend_core::{
-    Backend, BackendError, BackendOptions, BackendOutput, Diagnostic, DiagnosticLevel,
+    Backend, BackendError, BackendOptions, BackendOutput, Diagnostic, DiagnosticLevel, Precision,
 };
 use nxpu_backend_onnx::OnnxBackend;
 use nxpu_ir::Module;
@@ -20,6 +20,10 @@ impl Backend for QualcommBackend {
 
     fn targets(&self) -> &[&str] {
         &["qualcomm", "hexagon-npu"]
+    }
+
+    fn preferred_precision(&self) -> Precision {
+        Precision::Int8
     }
 
     fn compile(

--- a/crates/nxpu-backend-stablehlo/src/lower.rs
+++ b/crates/nxpu-backend-stablehlo/src/lower.rs
@@ -27,7 +27,9 @@ fn onnx_to_mlir_type(onnx_dt: i32) -> &'static str {
     match onnx_dt {
         data_type::FLOAT => "f32",
         data_type::FLOAT16 => "f16",
+        data_type::BFLOAT16 => "bf16",
         data_type::INT32 => "i32",
+        data_type::INT8 => "i8",
         data_type::UINT32 => "ui32",
         data_type::BOOL => "i1",
         _ => "f32",

--- a/crates/nxpu-backend-tflite/src/lower.rs
+++ b/crates/nxpu-backend-tflite/src/lower.rs
@@ -64,6 +64,7 @@ fn onnx_to_tflite_type(onnx_dt: i32) -> i8 {
         data_type::INT32 => tensor_type::INT32,
         data_type::UINT32 => tensor_type::UINT32,
         data_type::BOOL => tensor_type::BOOL,
+        data_type::INT8 => tensor_type::INT8,
         _ => tensor_type::FLOAT32,
     }
 }

--- a/crates/nxpu-e2e-tests/Cargo.toml
+++ b/crates/nxpu-e2e-tests/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "nxpu-e2e-tests"
+description = "End-to-end integration tests for NxPU"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+publish = false
+
+[dependencies]
+
+[dev-dependencies]
+nxpu-parser = { path = "../nxpu-parser" }
+nxpu-ir = { path = "../nxpu-ir" }
+nxpu-opt = { path = "../nxpu-opt" }
+nxpu-backend-core = { path = "../nxpu-backend-core" }
+nxpu-backend-onnx = { path = "../nxpu-backend-onnx" }
+nxpu-backend-tflite = { path = "../nxpu-backend-tflite" }
+nxpu-backend-coreml = { path = "../nxpu-backend-coreml" }
+nxpu-backend-stablehlo = { path = "../nxpu-backend-stablehlo" }
+prost = "0.13"

--- a/crates/nxpu-e2e-tests/src/lib.rs
+++ b/crates/nxpu-e2e-tests/src/lib.rs
@@ -1,0 +1,1 @@
+// Test-only crate — no library code.

--- a/crates/nxpu-e2e-tests/tests/bench.rs
+++ b/crates/nxpu-e2e-tests/tests/bench.rs
@@ -1,0 +1,74 @@
+mod common;
+
+use std::time::Instant;
+
+use nxpu_backend_coreml::CoreMlBackend;
+use nxpu_backend_onnx::OnnxBackend;
+use nxpu_backend_stablehlo::StableHloBackend;
+use nxpu_backend_tflite::TfLiteBackend;
+
+fn bench_backend(name: &str, source: &str, backend: &dyn nxpu_backend_core::Backend) {
+    let start = Instant::now();
+    let output = common::compile_wgsl(source, backend, 1);
+    let elapsed = start.elapsed();
+
+    let size: usize = output
+        .files
+        .iter()
+        .map(|f| match &f.content {
+            nxpu_backend_core::OutputContent::Binary(b) => b.len(),
+            nxpu_backend_core::OutputContent::Text(t) => t.len(),
+        })
+        .sum();
+
+    eprintln!("{name}: {elapsed:?}, output size: {size} bytes");
+    assert!(elapsed.as_secs() < 1, "{name} took too long: {elapsed:?}");
+}
+
+#[test]
+fn bench_onnx_matmul() {
+    let source = common::load_example("matmul");
+    bench_backend("ONNX/matmul", &source, &OnnxBackend);
+}
+
+#[test]
+fn bench_onnx_vecadd() {
+    let source = common::load_example("vecadd");
+    bench_backend("ONNX/vecadd", &source, &OnnxBackend);
+}
+
+#[test]
+fn bench_tflite_matmul() {
+    let source = common::load_example("matmul");
+    bench_backend("TFLite/matmul", &source, &TfLiteBackend);
+}
+
+#[test]
+fn bench_tflite_vecadd() {
+    let source = common::load_example("vecadd");
+    bench_backend("TFLite/vecadd", &source, &TfLiteBackend);
+}
+
+#[test]
+fn bench_coreml_matmul() {
+    let source = common::load_example("matmul");
+    bench_backend("CoreML/matmul", &source, &CoreMlBackend);
+}
+
+#[test]
+fn bench_coreml_vecadd() {
+    let source = common::load_example("vecadd");
+    bench_backend("CoreML/vecadd", &source, &CoreMlBackend);
+}
+
+#[test]
+fn bench_stablehlo_matmul() {
+    let source = common::load_example("matmul");
+    bench_backend("StableHLO/matmul", &source, &StableHloBackend);
+}
+
+#[test]
+fn bench_stablehlo_vecadd() {
+    let source = common::load_example("vecadd");
+    bench_backend("StableHLO/vecadd", &source, &StableHloBackend);
+}

--- a/crates/nxpu-e2e-tests/tests/common/mod.rs
+++ b/crates/nxpu-e2e-tests/tests/common/mod.rs
@@ -1,0 +1,83 @@
+use nxpu_backend_core::{Backend, BackendOptions, BackendOutput, OutputContent};
+#[allow(unused_imports)]
+use nxpu_ir::Module;
+use nxpu_opt::{OptLevel, PassManager};
+
+/// Parse WGSL source, optimize at the given level, and compile with the backend.
+#[allow(dead_code)]
+pub fn compile_wgsl(source: &str, backend: &dyn Backend, opt_level: u8) -> BackendOutput {
+    let mut module = nxpu_parser::parse(source).expect("WGSL parse failed");
+    let level = match opt_level {
+        0 => OptLevel::O0,
+        2 => OptLevel::O2,
+        _ => OptLevel::O1,
+    };
+    PassManager::for_level(level).run(&mut module);
+    backend
+        .compile(
+            &module,
+            &BackendOptions {
+                opt_level,
+                ..Default::default()
+            },
+        )
+        .expect("backend compilation failed")
+}
+
+/// Parse WGSL source, optimize, run a quantization pass, and compile.
+#[allow(dead_code)]
+pub fn compile_wgsl_with_pass(
+    source: &str,
+    pass: &dyn nxpu_opt::Pass,
+    backend: &dyn Backend,
+    opt_level: u8,
+) -> BackendOutput {
+    let mut module = nxpu_parser::parse(source).expect("WGSL parse failed");
+    let level = match opt_level {
+        0 => OptLevel::O0,
+        2 => OptLevel::O2,
+        _ => OptLevel::O1,
+    };
+    PassManager::for_level(level).run(&mut module);
+    pass.run(&mut module);
+    backend
+        .compile(
+            &module,
+            &BackendOptions {
+                opt_level,
+                ..Default::default()
+            },
+        )
+        .expect("backend compilation failed")
+}
+
+/// Load an example WGSL file by name (without extension).
+#[allow(dead_code)]
+pub fn load_example(name: &str) -> String {
+    let path = format!("{}/../../examples/{name}.wgsl", env!("CARGO_MANIFEST_DIR"));
+    std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("failed to load {path}: {e}"))
+}
+
+/// Extract the first binary output from a `BackendOutput`.
+#[allow(dead_code)]
+pub fn first_binary(output: &BackendOutput) -> &[u8] {
+    match &output.files[0].content {
+        OutputContent::Binary(b) => b,
+        OutputContent::Text(_) => panic!("expected binary output, got text"),
+    }
+}
+
+/// Extract the first text output from a `BackendOutput`.
+#[allow(dead_code)]
+pub fn first_text(output: &BackendOutput) -> &str {
+    match &output.files[0].content {
+        OutputContent::Text(t) => t,
+        OutputContent::Binary(_) => panic!("expected text output, got binary"),
+    }
+}
+
+/// Parse WGSL to Module (no optimization).
+#[allow(dead_code)]
+pub fn parse_wgsl(source: &str) -> Module {
+    nxpu_parser::parse(source).expect("WGSL parse failed")
+}

--- a/crates/nxpu-e2e-tests/tests/e2e_coreml.rs
+++ b/crates/nxpu-e2e-tests/tests/e2e_coreml.rs
@@ -1,0 +1,66 @@
+mod common;
+
+use nxpu_backend_coreml::CoreMlBackend;
+use nxpu_backend_coreml::proto::{self, Model, model};
+use prost::Message;
+
+fn decode_coreml(output: &nxpu_backend_core::BackendOutput) -> Model {
+    let bytes = common::first_binary(output);
+    Model::decode(bytes.as_ref()).expect("failed to decode CoreML model")
+}
+
+fn get_mil_ops(model: &Model) -> &[proto::MlOperation] {
+    let prog = match model.r#type.as_ref().unwrap() {
+        model::Type::MlProgram(p) => p,
+    };
+    &prog.functions[0].block.as_ref().unwrap().operations
+}
+
+#[test]
+fn matmul_coreml_structure() {
+    let source = common::load_example("matmul");
+    let output = common::compile_wgsl(&source, &CoreMlBackend, 1);
+    let model = decode_coreml(&output);
+    assert_eq!(model.specification_version, proto::SPECIFICATION_VERSION);
+    let ops = get_mil_ops(&model);
+    assert_eq!(ops.len(), 1);
+    assert_eq!(ops[0].r#type, "matmul");
+}
+
+#[test]
+fn vecadd_coreml_add_op() {
+    let source = common::load_example("vecadd");
+    let output = common::compile_wgsl(&source, &CoreMlBackend, 1);
+    let model = decode_coreml(&output);
+    let ops = get_mil_ops(&model);
+    assert_eq!(ops[0].r#type, "add");
+}
+
+#[test]
+fn vecsub_coreml_sub_op() {
+    let source = common::load_example("vecsub");
+    let output = common::compile_wgsl(&source, &CoreMlBackend, 1);
+    let model = decode_coreml(&output);
+    let ops = get_mil_ops(&model);
+    assert_eq!(ops[0].r#type, "sub");
+}
+
+#[test]
+fn vecmul_coreml_mul_op() {
+    let source = common::load_example("vecmul");
+    let output = common::compile_wgsl(&source, &CoreMlBackend, 1);
+    let model = decode_coreml(&output);
+    let ops = get_mil_ops(&model);
+    assert_eq!(ops[0].r#type, "mul");
+}
+
+#[test]
+fn matmul_all_opt_levels() {
+    let source = common::load_example("matmul");
+    for level in [0, 1, 2] {
+        let output = common::compile_wgsl(&source, &CoreMlBackend, level);
+        let model = decode_coreml(&output);
+        let ops = get_mil_ops(&model);
+        assert_eq!(ops[0].r#type, "matmul", "failed at opt level {level}");
+    }
+}

--- a/crates/nxpu-e2e-tests/tests/e2e_onnx.rs
+++ b/crates/nxpu-e2e-tests/tests/e2e_onnx.rs
@@ -1,0 +1,94 @@
+mod common;
+
+use nxpu_backend_onnx::OnnxBackend;
+use nxpu_backend_onnx::proto::{ModelProto, data_type};
+use prost::Message;
+
+fn decode_onnx(output: &nxpu_backend_core::BackendOutput) -> ModelProto {
+    let bytes = common::first_binary(output);
+    ModelProto::decode(bytes.as_ref()).expect("failed to decode ONNX model")
+}
+
+// --- MatMul ---
+
+#[test]
+fn matmul_o0() {
+    let source = common::load_example("matmul");
+    let output = common::compile_wgsl(&source, &OnnxBackend, 0);
+    let model = decode_onnx(&output);
+    let graph = model.graph.as_ref().unwrap();
+    assert_eq!(graph.node.len(), 1);
+    assert_eq!(graph.node[0].op_type, "MatMul");
+}
+
+#[test]
+fn matmul_o1() {
+    let source = common::load_example("matmul");
+    let output = common::compile_wgsl(&source, &OnnxBackend, 1);
+    let model = decode_onnx(&output);
+    let graph = model.graph.as_ref().unwrap();
+    assert_eq!(graph.node[0].op_type, "MatMul");
+    // Verify tensor data types are FLOAT.
+    for input in &graph.input {
+        let tt = input.r#type.as_ref().unwrap();
+        let tv = tt.value.as_ref().unwrap();
+        let nxpu_backend_onnx::proto::type_proto::Value::TensorType(t) = tv;
+        assert_eq!(t.elem_type, data_type::FLOAT);
+    }
+}
+
+#[test]
+fn matmul_o2() {
+    let source = common::load_example("matmul");
+    let output = common::compile_wgsl(&source, &OnnxBackend, 2);
+    let model = decode_onnx(&output);
+    assert_eq!(model.graph.unwrap().node[0].op_type, "MatMul");
+}
+
+// --- VecAdd ---
+
+#[test]
+fn vecadd_produces_add_node() {
+    let source = common::load_example("vecadd");
+    let output = common::compile_wgsl(&source, &OnnxBackend, 1);
+    let model = decode_onnx(&output);
+    let graph = model.graph.unwrap();
+    assert_eq!(graph.node.len(), 1);
+    assert_eq!(graph.node[0].op_type, "Add");
+}
+
+// --- VecSub ---
+
+#[test]
+fn vecsub_produces_sub_node() {
+    let source = common::load_example("vecsub");
+    let output = common::compile_wgsl(&source, &OnnxBackend, 1);
+    let model = decode_onnx(&output);
+    assert_eq!(model.graph.unwrap().node[0].op_type, "Sub");
+}
+
+// --- VecMul ---
+
+#[test]
+fn vecmul_produces_mul_node() {
+    let source = common::load_example("vecmul");
+    let output = common::compile_wgsl(&source, &OnnxBackend, 1);
+    let model = decode_onnx(&output);
+    assert_eq!(model.graph.unwrap().node[0].op_type, "Mul");
+}
+
+// --- All opt levels for vecadd ---
+
+#[test]
+fn vecadd_all_opt_levels() {
+    let source = common::load_example("vecadd");
+    for level in [0, 1, 2] {
+        let output = common::compile_wgsl(&source, &OnnxBackend, level);
+        let model = decode_onnx(&output);
+        assert_eq!(
+            model.graph.unwrap().node[0].op_type,
+            "Add",
+            "failed at opt level {level}"
+        );
+    }
+}

--- a/crates/nxpu-e2e-tests/tests/e2e_quantize.rs
+++ b/crates/nxpu-e2e-tests/tests/e2e_quantize.rs
@@ -1,0 +1,83 @@
+mod common;
+
+use nxpu_backend_onnx::OnnxBackend;
+use nxpu_backend_onnx::proto::{ModelProto, data_type, type_proto};
+use nxpu_backend_stablehlo::StableHloBackend;
+use nxpu_opt::{F32ToF16, F32ToInt8};
+use prost::Message;
+
+fn decode_onnx(output: &nxpu_backend_core::BackendOutput) -> ModelProto {
+    let bytes = common::first_binary(output);
+    ModelProto::decode(bytes.as_ref()).expect("failed to decode ONNX model")
+}
+
+fn get_input_elem_types(model: &ModelProto) -> Vec<i32> {
+    model
+        .graph
+        .as_ref()
+        .unwrap()
+        .input
+        .iter()
+        .map(|vi| {
+            let tt = vi.r#type.as_ref().unwrap();
+            let type_proto::Value::TensorType(t) = tt.value.as_ref().unwrap();
+            t.elem_type
+        })
+        .collect()
+}
+
+#[test]
+fn f32_to_f16_onnx_pipeline() {
+    let source = common::load_example("vecadd");
+    let output = common::compile_wgsl_with_pass(&source, &F32ToF16, &OnnxBackend, 1);
+    let model = decode_onnx(&output);
+    let types = get_input_elem_types(&model);
+    for dt in &types {
+        assert_eq!(*dt, data_type::FLOAT16, "expected FLOAT16, got {dt}");
+    }
+}
+
+#[test]
+fn f32_to_int8_onnx_pipeline() {
+    let source = common::load_example("vecadd");
+    let output = common::compile_wgsl_with_pass(&source, &F32ToInt8::default(), &OnnxBackend, 1);
+    let model = decode_onnx(&output);
+    let types = get_input_elem_types(&model);
+    for dt in &types {
+        assert_eq!(*dt, data_type::INT8, "expected INT8, got {dt}");
+    }
+}
+
+#[test]
+fn f32_to_f16_stablehlo_pipeline() {
+    let source = common::load_example("matmul");
+    let output = common::compile_wgsl_with_pass(&source, &F32ToF16, &StableHloBackend, 1);
+    let mlir = common::first_text(&output);
+    assert!(
+        mlir.contains("f16"),
+        "expected f16 types in MLIR output:\n{mlir}"
+    );
+}
+
+#[test]
+fn f32_to_int8_stablehlo_pipeline() {
+    let source = common::load_example("matmul");
+    let output =
+        common::compile_wgsl_with_pass(&source, &F32ToInt8::default(), &StableHloBackend, 1);
+    let mlir = common::first_text(&output);
+    assert!(
+        mlir.contains("i8"),
+        "expected i8 types in MLIR output:\n{mlir}"
+    );
+}
+
+#[test]
+fn matmul_f32_to_f16_onnx() {
+    let source = common::load_example("matmul");
+    let output = common::compile_wgsl_with_pass(&source, &F32ToF16, &OnnxBackend, 1);
+    let model = decode_onnx(&output);
+    let types = get_input_elem_types(&model);
+    for dt in &types {
+        assert_eq!(*dt, data_type::FLOAT16);
+    }
+}

--- a/crates/nxpu-e2e-tests/tests/e2e_stablehlo.rs
+++ b/crates/nxpu-e2e-tests/tests/e2e_stablehlo.rs
@@ -1,0 +1,49 @@
+mod common;
+
+use nxpu_backend_stablehlo::StableHloBackend;
+
+#[test]
+fn matmul_stablehlo_dot_general() {
+    let source = common::load_example("matmul");
+    let output = common::compile_wgsl(&source, &StableHloBackend, 1);
+    let mlir = common::first_text(&output);
+    assert!(mlir.contains("stablehlo.dot_general"));
+    assert!(mlir.contains("module @"));
+}
+
+#[test]
+fn vecadd_stablehlo_add() {
+    let source = common::load_example("vecadd");
+    let output = common::compile_wgsl(&source, &StableHloBackend, 1);
+    let mlir = common::first_text(&output);
+    assert!(mlir.contains("stablehlo.add"));
+}
+
+#[test]
+fn vecsub_stablehlo_subtract() {
+    let source = common::load_example("vecsub");
+    let output = common::compile_wgsl(&source, &StableHloBackend, 1);
+    let mlir = common::first_text(&output);
+    assert!(mlir.contains("stablehlo.subtract"));
+}
+
+#[test]
+fn vecmul_stablehlo_multiply() {
+    let source = common::load_example("vecmul");
+    let output = common::compile_wgsl(&source, &StableHloBackend, 1);
+    let mlir = common::first_text(&output);
+    assert!(mlir.contains("stablehlo.multiply"));
+}
+
+#[test]
+fn matmul_all_opt_levels() {
+    let source = common::load_example("matmul");
+    for level in [0, 1, 2] {
+        let output = common::compile_wgsl(&source, &StableHloBackend, level);
+        let mlir = common::first_text(&output);
+        assert!(
+            mlir.contains("stablehlo.dot_general"),
+            "failed at opt level {level}"
+        );
+    }
+}

--- a/crates/nxpu-e2e-tests/tests/e2e_tflite.rs
+++ b/crates/nxpu-e2e-tests/tests/e2e_tflite.rs
@@ -1,0 +1,47 @@
+mod common;
+
+use nxpu_backend_tflite::TfLiteBackend;
+
+#[test]
+fn matmul_tflite_magic() {
+    let source = common::load_example("matmul");
+    let output = common::compile_wgsl(&source, &TfLiteBackend, 1);
+    let bytes = common::first_binary(&output);
+    assert!(bytes.len() > 8);
+    assert_eq!(&bytes[4..8], b"TFL3");
+}
+
+#[test]
+fn vecadd_tflite_magic() {
+    let source = common::load_example("vecadd");
+    let output = common::compile_wgsl(&source, &TfLiteBackend, 1);
+    let bytes = common::first_binary(&output);
+    assert!(bytes.len() > 8);
+    assert_eq!(&bytes[4..8], b"TFL3");
+}
+
+#[test]
+fn vecsub_tflite_magic() {
+    let source = common::load_example("vecsub");
+    let output = common::compile_wgsl(&source, &TfLiteBackend, 1);
+    let bytes = common::first_binary(&output);
+    assert_eq!(&bytes[4..8], b"TFL3");
+}
+
+#[test]
+fn vecmul_tflite_magic() {
+    let source = common::load_example("vecmul");
+    let output = common::compile_wgsl(&source, &TfLiteBackend, 1);
+    let bytes = common::first_binary(&output);
+    assert_eq!(&bytes[4..8], b"TFL3");
+}
+
+#[test]
+fn matmul_all_opt_levels() {
+    let source = common::load_example("matmul");
+    for level in [0, 1, 2] {
+        let output = common::compile_wgsl(&source, &TfLiteBackend, level);
+        let bytes = common::first_binary(&output);
+        assert_eq!(&bytes[4..8], b"TFL3", "failed at opt level {level}");
+    }
+}

--- a/crates/nxpu-ir/src/display.rs
+++ b/crates/nxpu-ir/src/display.rs
@@ -18,6 +18,7 @@ impl fmt::Display for ScalarKind {
             Self::Sint => write!(f, "sint"),
             Self::Uint => write!(f, "uint"),
             Self::Float => write!(f, "float"),
+            Self::BFloat => write!(f, "bfloat"),
         }
     }
 }
@@ -29,6 +30,7 @@ impl fmt::Display for Scalar {
             ScalarKind::Sint => write!(f, "i{}", self.width * 8),
             ScalarKind::Uint => write!(f, "u{}", self.width * 8),
             ScalarKind::Float => write!(f, "f{}", self.width * 8),
+            ScalarKind::BFloat => write!(f, "bf{}", self.width * 8),
         }
     }
 }

--- a/crates/nxpu-ir/src/types.rs
+++ b/crates/nxpu-ir/src/types.rs
@@ -16,6 +16,8 @@ pub enum ScalarKind {
     Uint,
     /// Floating point.
     Float,
+    /// Brain floating point.
+    BFloat,
 }
 
 /// A scalar type: kind + byte width.
@@ -45,6 +47,18 @@ impl Scalar {
     pub const F32: Self = Self {
         kind: ScalarKind::Float,
         width: 4,
+    };
+    pub const I8: Self = Self {
+        kind: ScalarKind::Sint,
+        width: 1,
+    };
+    pub const U8: Self = Self {
+        kind: ScalarKind::Uint,
+        width: 1,
+    };
+    pub const BF16: Self = Self {
+        kind: ScalarKind::BFloat,
+        width: 2,
     };
 }
 

--- a/crates/nxpu-opt/src/lib.rs
+++ b/crates/nxpu-opt/src/lib.rs
@@ -7,10 +7,12 @@
 mod const_fold;
 mod dce;
 mod fma_fusion;
+pub mod quantize;
 
 pub use const_fold::ConstantFolding;
 pub use dce::DeadCodeElimination;
 pub use fma_fusion::FmaFusion;
+pub use quantize::{F32ToBf16, F32ToF16, F32ToInt8};
 
 use std::fmt::Debug;
 

--- a/crates/nxpu-opt/src/quantize.rs
+++ b/crates/nxpu-opt/src/quantize.rs
@@ -1,0 +1,260 @@
+//! Precision conversion passes for NPU quantization.
+//!
+//! Rewrites `array<f32>` global variable types to lower-precision
+//! element types suitable for specific NPU backends.
+
+use nxpu_ir::{Handle, Module, Scalar, Type, TypeInner};
+
+use crate::Pass;
+
+/// Parameters describing how floating-point values were quantized to integers.
+#[derive(Clone, Debug)]
+pub struct QuantizationParams {
+    pub scale: f32,
+    pub zero_point: i32,
+}
+
+/// Rewrite array element precision from F32 to a target scalar type.
+///
+/// 1. Insert the target scalar type into the module's type arena.
+/// 2. Find the existing F32 scalar handle.
+/// 3. For each Array type whose `base == f32_handle`, insert a new Array type
+///    with the target base and adjusted stride.
+/// 4. Update `GlobalVariable.ty` handles via the remap.
+fn rewrite_array_elem_precision(module: &mut Module, target_scalar: Scalar) -> bool {
+    // Insert target scalar type.
+    let target_scalar_handle = module.types.insert(Type {
+        name: None,
+        inner: TypeInner::Scalar(target_scalar),
+    });
+
+    // Find existing F32 scalar handle.
+    let f32_handle = module.types.insert(Type {
+        name: None,
+        inner: TypeInner::Scalar(Scalar::F32),
+    });
+
+    // Collect array types that need rewriting: (old_array_handle -> new_array_handle).
+    let mut remap: Vec<(Handle<Type>, Handle<Type>)> = Vec::new();
+
+    // First pass: find all array types with f32 base.
+    let array_types: Vec<_> = module
+        .types
+        .iter()
+        .filter_map(|(handle, ty)| {
+            if let TypeInner::Array { base, size, stride } = &ty.inner
+                && *base == f32_handle
+            {
+                return Some((handle, *size, *stride));
+            }
+            None
+        })
+        .collect();
+
+    // Second pass: insert new array types and build remap.
+    for (old_handle, size, old_stride) in array_types {
+        let new_stride = old_stride * (target_scalar.width as u32) / (Scalar::F32.width as u32);
+        let new_handle = module.types.insert(Type {
+            name: None,
+            inner: TypeInner::Array {
+                base: target_scalar_handle,
+                size,
+                stride: new_stride,
+            },
+        });
+        if old_handle != new_handle {
+            remap.push((old_handle, new_handle));
+        }
+    }
+
+    if remap.is_empty() {
+        return false;
+    }
+
+    // Apply remap to global variables.
+    let mut changed = false;
+    for (_handle, gv) in module.global_variables.iter_mut() {
+        for (old, new) in &remap {
+            if gv.ty == *old {
+                gv.ty = *new;
+                changed = true;
+            }
+        }
+    }
+
+    changed
+}
+
+/// Converts `array<f32>` global variables to `array<f16>`.
+#[derive(Debug)]
+pub struct F32ToF16;
+
+impl Pass for F32ToF16 {
+    fn name(&self) -> &str {
+        "F32ToF16"
+    }
+
+    fn run(&self, module: &mut Module) -> bool {
+        rewrite_array_elem_precision(module, Scalar::F16)
+    }
+}
+
+/// Converts `array<f32>` global variables to `array<bf16>`.
+#[derive(Debug)]
+pub struct F32ToBf16;
+
+impl Pass for F32ToBf16 {
+    fn name(&self) -> &str {
+        "F32ToBf16"
+    }
+
+    fn run(&self, module: &mut Module) -> bool {
+        rewrite_array_elem_precision(module, Scalar::BF16)
+    }
+}
+
+/// Converts `array<f32>` global variables to `array<i8>`.
+///
+/// Stores default quantization parameters (scale=1.0, zero_point=0)
+/// for downstream consumers that need them.
+#[derive(Debug)]
+pub struct F32ToInt8 {
+    pub params: QuantizationParams,
+}
+
+impl Default for F32ToInt8 {
+    fn default() -> Self {
+        Self {
+            params: QuantizationParams {
+                scale: 1.0,
+                zero_point: 0,
+            },
+        }
+    }
+}
+
+impl Pass for F32ToInt8 {
+    fn name(&self) -> &str {
+        "F32ToInt8"
+    }
+
+    fn run(&self, module: &mut Module) -> bool {
+        rewrite_array_elem_precision(module, Scalar::I8)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nxpu_ir::*;
+
+    fn make_f32_array_module() -> (Module, Handle<GlobalVariable>, Handle<GlobalVariable>) {
+        let mut module = Module::default();
+
+        let f32_ty = module.types.insert(Type {
+            name: None,
+            inner: TypeInner::Scalar(Scalar::F32),
+        });
+        let array_f32 = module.types.insert(Type {
+            name: None,
+            inner: TypeInner::Array {
+                base: f32_ty,
+                size: ArraySize::Dynamic,
+                stride: 4,
+            },
+        });
+
+        let h0 = module.global_variables.append(GlobalVariable {
+            name: Some("a".into()),
+            space: AddressSpace::Storage {
+                access: StorageAccess::LOAD,
+            },
+            binding: Some(ResourceBinding {
+                group: 0,
+                binding: 0,
+            }),
+            ty: array_f32,
+            init: None,
+        });
+        let h1 = module.global_variables.append(GlobalVariable {
+            name: Some("b".into()),
+            space: AddressSpace::Storage {
+                access: StorageAccess::LOAD,
+            },
+            binding: Some(ResourceBinding {
+                group: 0,
+                binding: 1,
+            }),
+            ty: array_f32,
+            init: None,
+        });
+
+        (module, h0, h1)
+    }
+
+    fn get_array_elem_scalar(module: &Module, gv_handle: Handle<GlobalVariable>) -> Scalar {
+        let ty = &module.types[module.global_variables[gv_handle].ty];
+        match &ty.inner {
+            TypeInner::Array { base, .. } => match &module.types[*base].inner {
+                TypeInner::Scalar(s) => *s,
+                other => panic!("expected Scalar, got {other:?}"),
+            },
+            other => panic!("expected Array, got {other:?}"),
+        }
+    }
+
+    fn get_array_stride(module: &Module, gv_handle: Handle<GlobalVariable>) -> u32 {
+        let ty = &module.types[module.global_variables[gv_handle].ty];
+        match &ty.inner {
+            TypeInner::Array { stride, .. } => *stride,
+            other => panic!("expected Array, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn f32_to_f16() {
+        let (mut module, h0, h1) = make_f32_array_module();
+        let changed = F32ToF16.run(&mut module);
+        assert!(changed);
+
+        assert_eq!(get_array_elem_scalar(&module, h0), Scalar::F16);
+        assert_eq!(get_array_elem_scalar(&module, h1), Scalar::F16);
+        assert_eq!(get_array_stride(&module, h0), 2);
+    }
+
+    #[test]
+    fn f32_to_bf16() {
+        let (mut module, h0, _h1) = make_f32_array_module();
+        let changed = F32ToBf16.run(&mut module);
+        assert!(changed);
+
+        assert_eq!(get_array_elem_scalar(&module, h0), Scalar::BF16);
+        assert_eq!(get_array_stride(&module, h0), 2);
+    }
+
+    #[test]
+    fn f32_to_int8() {
+        let (mut module, h0, _h1) = make_f32_array_module();
+        let changed = F32ToInt8::default().run(&mut module);
+        assert!(changed);
+
+        assert_eq!(get_array_elem_scalar(&module, h0), Scalar::I8);
+        assert_eq!(get_array_stride(&module, h0), 1);
+    }
+
+    #[test]
+    fn no_change_when_no_f32_arrays() {
+        let mut module = Module::default();
+        let changed = F32ToF16.run(&mut module);
+        assert!(!changed);
+    }
+
+    #[test]
+    fn idempotent() {
+        let (mut module, _h0, _h1) = make_f32_array_module();
+        F32ToF16.run(&mut module);
+        let changed = F32ToF16.run(&mut module);
+        // After first rewrite there are no more f32 arrays, so no change.
+        assert!(!changed);
+    }
+}

--- a/examples/vecadd.wgsl
+++ b/examples/vecadd.wgsl
@@ -1,0 +1,19 @@
+// Element-wise vector addition — target for NPU transpilation
+
+@group(0) @binding(0) var<storage, read> a: array<f32>;
+@group(0) @binding(1) var<storage, read> b: array<f32>;
+@group(0) @binding(2) var<storage, read_write> c: array<f32>;
+
+struct Params {
+  N: u32,
+}
+@group(0) @binding(3) var<uniform> params: Params;
+
+@compute @workgroup_size(256)
+fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
+  let idx = gid.x;
+  if (idx >= params.N) {
+    return;
+  }
+  c[idx] = a[idx] + b[idx];
+}

--- a/examples/vecmul.wgsl
+++ b/examples/vecmul.wgsl
@@ -1,0 +1,19 @@
+// Element-wise vector multiplication — target for NPU transpilation
+
+@group(0) @binding(0) var<storage, read> a: array<f32>;
+@group(0) @binding(1) var<storage, read> b: array<f32>;
+@group(0) @binding(2) var<storage, read_write> c: array<f32>;
+
+struct Params {
+  N: u32,
+}
+@group(0) @binding(3) var<uniform> params: Params;
+
+@compute @workgroup_size(256)
+fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
+  let idx = gid.x;
+  if (idx >= params.N) {
+    return;
+  }
+  c[idx] = a[idx] * b[idx];
+}

--- a/examples/vecsub.wgsl
+++ b/examples/vecsub.wgsl
@@ -1,0 +1,19 @@
+// Element-wise vector subtraction — target for NPU transpilation
+
+@group(0) @binding(0) var<storage, read> a: array<f32>;
+@group(0) @binding(1) var<storage, read> b: array<f32>;
+@group(0) @binding(2) var<storage, read_write> c: array<f32>;
+
+struct Params {
+  N: u32,
+}
+@group(0) @binding(3) var<uniform> params: Params;
+
+@compute @workgroup_size(256)
+fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
+  let idx = gid.x;
+  if (idx >= params.N) {
+    return;
+  }
+  c[idx] = a[idx] - b[idx];
+}


### PR DESCRIPTION
## Summary

- **Issue #18 (Quantization):** Add precision conversion infrastructure — `ScalarKind::BFloat`, `Scalar::I8/U8/BF16` IR types, `Precision`/`PrecisionPolicy` enums, three quantization passes (`F32ToF16`, `F32ToBf16`, `F32ToInt8`), type mappings across all 4 primary backends, per-vendor `preferred_precision()` (F16 for CoreML/Intel, Int8 for Ethos/Qualcomm/AMD), and a CLI `--precision` flag with auto-resolution
- **Issue #19 (E2E Tests):** Add comprehensive end-to-end test suite — 3 new WGSL examples (`vecadd`, `vecsub`, `vecmul`), `nxpu-e2e-tests` crate with 35 integration tests covering ONNX, TFLite, CoreML, StableHLO backends, quantization pipeline validation, and performance benchmarks
- All 164 workspace tests pass, zero clippy warnings, formatting clean

## Test plan

- [x] `cargo test -p nxpu-opt` — quantization pass unit tests (5 tests)
- [x] `cargo test -p nxpu-e2e-tests` — all E2E tests pass (35 tests)
- [x] `cargo test --workspace` — full workspace passes (164 tests)
- [x] `cargo clippy --workspace` — no warnings
- [x] `cargo fmt --check` — clean

Closes #18, closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)