### PR TITLE
Fix LOW release quality issues #85-#92

### DIFF
--- a/crates/nxpu-analysis/src/fusion.rs
+++ b/crates/nxpu-analysis/src/fusion.rs
@@ -66,6 +66,15 @@ pub enum FusedActivation {
     Relu,
 }
 
+impl std::fmt::Display for FusedActivation {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            Self::None => "None",
+            Self::Relu => "Relu",
+        })
+    }
+}
+
 /// A pattern that may be fused from one or more classified patterns.
 #[derive(Debug, Clone)]
 pub enum FusedPattern {
@@ -83,6 +92,18 @@ pub enum FusedPattern {
         /// The original activation pattern (preserved for tensor connectivity).
         activation_pattern: Box<KernelPattern>,
     },
+}
+
+impl std::fmt::Display for FusedPattern {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Single(p) => write!(f, "{p}"),
+            Self::ConvBatchNorm { conv, .. } => write!(f, "{conv}+BatchNorm"),
+            Self::WithActivation {
+                base, activation, ..
+            } => write!(f, "{base}+{activation}"),
+        }
+    }
 }
 
 impl FusedPattern {

--- a/crates/nxpu-backend-coreml/src/lib.rs
+++ b/crates/nxpu-backend-coreml/src/lib.rs
@@ -12,6 +12,7 @@ use nxpu_ir::Module;
 use prost::Message;
 
 mod lower;
+#[doc(hidden)]
 pub mod proto;
 
 /// CoreML backend targeting Apple Neural Engine.

--- a/crates/nxpu-ir/src/arena.rs
+++ b/crates/nxpu-ir/src/arena.rs
@@ -132,7 +132,7 @@ impl<T> Range<T> {
     }
 
     /// Returns the handle one past the last element.
-    pub fn last(&self) -> Handle<T> {
+    pub fn end(&self) -> Handle<T> {
         Handle::new(self.last)
     }
 
@@ -359,7 +359,7 @@ mod tests {
         let range = Range::<u32>::from_index_range(2..5);
         assert!(!range.is_empty());
         assert_eq!(range.first().index(), 2);
-        assert_eq!(range.last().index(), 5);
+        assert_eq!(range.end().index(), 5);
         assert_eq!(range.index_range(), 2..5);
 
         let empty = Range::<u32>::from_index_range(3..3);

--- a/crates/nxpu-ir/src/func.rs
+++ b/crates/nxpu-ir/src/func.rs
@@ -11,35 +11,50 @@ use crate::types::Type;
 /// A function argument declaration.
 #[derive(Clone, Debug)]
 pub struct FunctionArgument {
+    /// Optional argument name.
     pub name: Option<String>,
+    /// The type of this argument.
     pub ty: Handle<Type>,
+    /// Optional binding (e.g. built-in or location).
     pub binding: Option<Binding>,
 }
 
 /// The return type and optional binding of a function.
 #[derive(Clone, Debug)]
 pub struct FunctionResult {
+    /// The return type.
     pub ty: Handle<Type>,
+    /// Optional binding for the return value.
     pub binding: Option<Binding>,
 }
 
 /// A function-local variable.
 #[derive(Clone, Debug)]
 pub struct LocalVariable {
+    /// Optional variable name.
     pub name: Option<String>,
+    /// The type of this variable.
     pub ty: Handle<Type>,
+    /// Optional initializer expression.
     pub init: Option<Handle<Expression>>,
 }
 
 /// An IR function.
 #[derive(Clone, Debug)]
 pub struct Function {
+    /// Optional function name.
     pub name: Option<String>,
+    /// Formal parameters.
     pub arguments: Vec<FunctionArgument>,
+    /// Return type and optional binding.
     pub result: Option<FunctionResult>,
+    /// Function-local variable declarations.
     pub local_variables: Arena<LocalVariable>,
+    /// Expression arena for this function.
     pub expressions: Arena<Expression>,
+    /// Map from expression handles to user-defined names.
     pub named_expressions: HashMap<Handle<Expression>, String>,
+    /// The function body.
     pub body: Block,
 }
 
@@ -61,8 +76,11 @@ impl Function {
 /// A compute shader entry point.
 #[derive(Clone, Debug)]
 pub struct EntryPoint {
+    /// Entry point name (matches the WGSL function name).
     pub name: String,
+    /// Workgroup dimensions `[x, y, z]`.
     pub workgroup_size: [u32; 3],
+    /// The entry point function body.
     pub function: Function,
 }
 

--- a/crates/nxpu-ir/src/global.rs
+++ b/crates/nxpu-ir/src/global.rs
@@ -57,7 +57,9 @@ pub enum AddressSpace {
 /// `@group(N) @binding(N)` resource binding.
 #[derive(Clone, Copy, Debug, Hash, Eq, PartialEq)]
 pub struct ResourceBinding {
+    /// Bind group index.
     pub group: u32,
+    /// Binding index within the group.
     pub binding: u32,
 }
 
@@ -88,10 +90,15 @@ pub enum Binding {
 /// A module-scope variable.
 #[derive(Clone, Debug)]
 pub struct GlobalVariable {
+    /// Optional variable name.
     pub name: Option<String>,
+    /// Address space (uniform, storage, etc.).
     pub space: AddressSpace,
+    /// Optional resource binding (`@group(N) @binding(N)`).
     pub binding: Option<ResourceBinding>,
+    /// The type of this variable.
     pub ty: Handle<Type>,
+    /// Optional initializer expression.
     pub init: Option<Handle<crate::Expression>>,
     /// Optional memory layout annotation for tensor data.
     pub layout: Option<crate::types::MemoryLayout>,

--- a/crates/nxpu-ir/src/stmt.rs
+++ b/crates/nxpu-ir/src/stmt.rs
@@ -36,6 +36,12 @@ impl std::ops::BitOr for Barrier {
     }
 }
 
+impl std::ops::BitOrAssign for Barrier {
+    fn bitor_assign(&mut self, rhs: Self) {
+        self.0 |= rhs.0;
+    }
+}
+
 /// A statement in the IR.
 ///
 /// Statements have side effects and/or control flow.

--- a/crates/nxpu-ir/src/types.rs
+++ b/crates/nxpu-ir/src/types.rs
@@ -23,7 +23,9 @@ pub enum ScalarKind {
 /// A scalar type: kind + byte width.
 #[derive(Clone, Copy, Debug, Hash, Eq, PartialEq, Ord, PartialOrd)]
 pub struct Scalar {
+    /// The kind of scalar (bool, int, float, etc.).
     pub kind: ScalarKind,
+    /// Width of the scalar in bytes.
     pub width: Bytes,
 }
 
@@ -189,15 +191,20 @@ impl MemoryLayout {
 /// A member of a struct type.
 #[derive(Clone, Debug, Hash, Eq, PartialEq)]
 pub struct StructMember {
+    /// Optional member name.
     pub name: Option<String>,
+    /// The type of this member.
     pub ty: Handle<Type>,
+    /// Byte offset within the struct.
     pub offset: u32,
 }
 
 /// A named type.
 #[derive(Clone, Debug, Hash, Eq, PartialEq)]
 pub struct Type {
+    /// Optional human-readable name.
     pub name: Option<String>,
+    /// The concrete type shape.
     pub inner: TypeInner,
 }
 


### PR DESCRIPTION
## Summary
- Add `fmt::Display` impls for 21 public types across `nxpu-backend-core` and `nxpu-analysis` (#85)
- Add `///` doc comments to 52 undocumented public struct fields in `nxpu-ir` and `nxpu-analysis` (#86)
- Add `#![warn(missing_docs)]` to `nxpu-backend-core` (the only fully-documented crate; `nxpu-ir` deferred — still has 154 undocumented items) (#87)
- Fix copy-pasted `op_name()` doc comments on `ActivationOp`, `ReduceOp`, `PoolKind` (#88)
- Rename `Range::last()` → `Range::end()` for clarity (#89)
- Add `BitOrAssign` impl for `Barrier` (#90)
- Workspace `keywords`/`categories` already present — no changes needed (#91)
- Add `#[doc(hidden)]` to CoreML `proto` module (#92)

## Test plan
- [x] `cargo fmt --check` — clean
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo test --workspace` — all pass

Closes #85, closes #86, closes #87, closes #88, closes #89, closes #90, closes #91, closes #92

🤖 Generated with [Claude Code](https://claude.com/claude-code)