### PR TITLE
Add fuzz testing for WGSL parser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,10 @@
 .DS_Store
 Thumbs.db
 
+# Fuzz
+fuzz/target/
+fuzz/artifacts/
+
 # Build artifacts
 *.o
 *.so

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,18 @@ cargo fmt --check
 cargo clippy --workspace --all-targets -- -D warnings
 ```
 
+## Fuzz Testing
+
+The WGSL parser has fuzz targets under `fuzz/`. Requires nightly Rust:
+
+```sh
+cargo install cargo-fuzz
+cargo +nightly fuzz run fuzz_parse   # Fuzz the WGSL parser (naga)
+cargo +nightly fuzz run fuzz_lower   # Fuzz parse + IR lowering
+```
+
+Stop with `Ctrl+C`. Crashes are saved in `fuzz/artifacts/`. If you find one, please open an issue.
+
 ## Pull Request Guidelines
 
 1. Fork the repository and create a feature branch from `main`.

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "nxpu-fuzz"
+version = "0.0.0"
+publish = false
+edition = "2021"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+naga = { version = "28", features = ["wgsl-in"] }
+nxpu-parser = { path = "../crates/nxpu-parser" }
+
+[workspace]
+
+[[bin]]
+name = "fuzz_parse"
+path = "fuzz_targets/fuzz_parse.rs"
+doc = false
+
+[[bin]]
+name = "fuzz_lower"
+path = "fuzz_targets/fuzz_lower.rs"
+doc = false

--- a/fuzz/corpus/fuzz_lower/attention.wgsl
+++ b/fuzz/corpus/fuzz_lower/attention.wgsl
@@ -1,0 +1,51 @@
+// Scaled dot-product attention.
+//
+// attn = softmax(Q * K^T / sqrt(d_k)) * V
+//
+// For each query position, computes attention scores against all key positions,
+// applies numerically stable softmax, then weights values.
+
+@group(0) @binding(0) var<storage, read> query: array<f32>;
+@group(0) @binding(1) var<storage, read> key: array<f32>;
+@group(0) @binding(2) var<storage, read> value: array<f32>;
+@group(0) @binding(3) var<storage, read_write> output: array<f32>;
+
+struct Params { seq_len: u32, d_k: u32 }
+@group(0) @binding(4) var<uniform> params: Params;
+
+@compute @workgroup_size(16, 16)
+fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
+  let row = gid.x;
+  let col = gid.y;
+  if (row >= params.seq_len || col >= params.d_k) { return; }
+
+  let scale = 1.0 / sqrt(f32(params.d_k));
+
+  // Compute attention scores: Q[row,:] dot K[j,:] for all j
+  // Then softmax over j dimension
+  var max_score: f32 = -1e30;
+  for (var j: u32 = 0u; j < params.seq_len; j = j + 1u) {
+    var score: f32 = 0.0;
+    for (var k: u32 = 0u; k < params.d_k; k = k + 1u) {
+      score = score + query[row * params.d_k + k] * key[j * params.d_k + k];
+    }
+    score = score * scale;
+    max_score = max(max_score, score);
+  }
+
+  // Compute softmax denominator and weighted sum
+  var sum_exp: f32 = 0.0;
+  var result: f32 = 0.0;
+  for (var j: u32 = 0u; j < params.seq_len; j = j + 1u) {
+    var score: f32 = 0.0;
+    for (var k: u32 = 0u; k < params.d_k; k = k + 1u) {
+      score = score + query[row * params.d_k + k] * key[j * params.d_k + k];
+    }
+    score = score * scale;
+    let w = exp(score - max_score);
+    sum_exp = sum_exp + w;
+    result = result + w * value[j * params.d_k + col];
+  }
+
+  output[row * params.d_k + col] = result / sum_exp;
+}

--- a/fuzz/corpus/fuzz_lower/batchnorm.wgsl
+++ b/fuzz/corpus/fuzz_lower/batchnorm.wgsl
@@ -1,0 +1,45 @@
+// Batch normalization — target for NPU transpilation
+// y = gamma * (x - mean) / sqrt(variance + epsilon) + beta
+
+@group(0) @binding(0) var<storage, read> x: array<f32>;
+@group(0) @binding(1) var<storage, read> gamma: array<f32>;
+@group(0) @binding(2) var<storage, read> beta: array<f32>;
+@group(0) @binding(3) var<storage, read_write> y: array<f32>;
+
+struct Params {
+  N: u32,
+  C: u32,
+  HW: u32,
+}
+@group(0) @binding(4) var<uniform> params: Params;
+
+@compute @workgroup_size(256)
+fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
+  let idx = gid.x;
+  let total = params.N * params.C * params.HW;
+  if (idx >= total) {
+    return;
+  }
+  let c = (idx / params.HW) % params.C;
+
+  // Compute channel mean
+  var mean: f32 = 0.0;
+  let ch_start = (idx / (params.C * params.HW)) * params.C * params.HW + c * params.HW;
+  for (var i: u32 = 0u; i < params.HW; i = i + 1u) {
+    mean = mean + x[ch_start + i];
+  }
+  mean = mean / f32(params.HW);
+
+  // Compute channel variance
+  var variance: f32 = 0.0;
+  for (var i: u32 = 0u; i < params.HW; i = i + 1u) {
+    let diff = x[ch_start + i] - mean;
+    variance = variance + diff * diff;
+  }
+  variance = variance / f32(params.HW);
+
+  // Normalize
+  let epsilon: f32 = 1e-5;
+  let normalized = (x[idx] - mean) / sqrt(variance + epsilon);
+  y[idx] = gamma[c] * normalized + beta[c];
+}

--- a/fuzz/corpus/fuzz_lower/concat.wgsl
+++ b/fuzz/corpus/fuzz_lower/concat.wgsl
@@ -1,0 +1,24 @@
+// Concatenate two 1D arrays along axis 0.
+//
+// output[i] = a[i]           if i < N_a
+// output[i] = b[i - N_a]    otherwise
+
+@group(0) @binding(0) var<storage, read> a: array<f32>;
+@group(0) @binding(1) var<storage, read> b: array<f32>;
+@group(0) @binding(2) var<storage, read_write> output: array<f32>;
+
+struct Params { N_a: u32, N_b: u32 }
+@group(0) @binding(3) var<uniform> params: Params;
+
+@compute @workgroup_size(256)
+fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
+  let idx = gid.x;
+  let total = params.N_a + params.N_b;
+  if (idx >= total) { return; }
+
+  if (idx < params.N_a) {
+    output[idx] = a[idx];
+  } else {
+    output[idx] = b[idx - params.N_a];
+  }
+}

--- a/fuzz/corpus/fuzz_lower/conv2d.wgsl
+++ b/fuzz/corpus/fuzz_lower/conv2d.wgsl
@@ -1,0 +1,43 @@
+// 2D convolution — target for NPU transpilation
+
+@group(0) @binding(0) var<storage, read> input: array<f32>;
+@group(0) @binding(1) var<storage, read> weight: array<f32>;
+@group(0) @binding(2) var<storage, read_write> output: array<f32>;
+
+struct Params {
+  N: u32,
+  IC: u32,
+  IH: u32,
+  IW: u32,
+  OC: u32,
+  KH: u32,
+  KW: u32,
+}
+@group(0) @binding(3) var<uniform> params: Params;
+
+@compute @workgroup_size(16, 16)
+fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
+  let oc = gid.x;
+  let oh = gid.y;
+  if (oc >= params.OC) {
+    return;
+  }
+
+  let ow_max = params.IW - params.KW + 1u;
+  for (var ow: u32 = 0u; ow < ow_max; ow = ow + 1u) {
+    var sum: f32 = 0.0;
+    for (var kh: u32 = 0u; kh < params.KH; kh = kh + 1u) {
+      for (var kw: u32 = 0u; kw < params.KW; kw = kw + 1u) {
+        for (var ic: u32 = 0u; ic < params.IC; ic = ic + 1u) {
+          let ih = oh + kh;
+          let iw = ow + kw;
+          let in_idx = ic * params.IH * params.IW + ih * params.IW + iw;
+          let w_idx = oc * params.IC * params.KH * params.KW + ic * params.KH * params.KW + kh * params.KW + kw;
+          sum = sum + input[in_idx] * weight[w_idx];
+        }
+      }
+    }
+    let out_idx = oc * (params.IH - params.KH + 1u) * ow_max + oh * ow_max + ow;
+    output[out_idx] = sum;
+  }
+}

--- a/fuzz/corpus/fuzz_lower/matmul.wgsl
+++ b/fuzz/corpus/fuzz_lower/matmul.wgsl
@@ -1,0 +1,28 @@
+// Matrix multiplication — target for NPU transpilation
+
+@group(0) @binding(0) var<storage, read> a: array<f32>;
+@group(0) @binding(1) var<storage, read> b: array<f32>;
+@group(0) @binding(2) var<storage, read_write> result: array<f32>;
+
+struct Params {
+  M: u32,
+  N: u32,
+  K: u32,
+}
+@group(0) @binding(3) var<uniform> params: Params;
+
+@compute @workgroup_size(16, 16)
+fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
+  let row = gid.x;
+  let col = gid.y;
+
+  if (row >= params.M || col >= params.N) {
+    return;
+  }
+
+  var sum: f32 = 0.0;
+  for (var k: u32 = 0u; k < params.K; k = k + 1u) {
+    sum = sum + a[row * params.K + k] * b[k * params.N + col];
+  }
+  result[row * params.N + col] = sum;
+}

--- a/fuzz/corpus/fuzz_lower/maxpool.wgsl
+++ b/fuzz/corpus/fuzz_lower/maxpool.wgsl
@@ -1,0 +1,35 @@
+// Max pooling 2D (2x2 kernel, stride 2) — target for NPU transpilation
+
+@group(0) @binding(0) var<storage, read> input: array<f32>;
+@group(0) @binding(1) var<storage, read_write> output: array<f32>;
+
+struct Params {
+  C: u32,
+  IH: u32,
+  IW: u32,
+  OH: u32,
+  OW: u32,
+}
+@group(0) @binding(2) var<uniform> params: Params;
+
+@compute @workgroup_size(16, 16)
+fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
+  let c = gid.x;
+  let oh = gid.y;
+  if (c >= params.C || oh >= params.OH) {
+    return;
+  }
+
+  for (var ow: u32 = 0u; ow < params.OW; ow = ow + 1u) {
+    var max_val: f32 = -3.402823e+38;
+    for (var kh: u32 = 0u; kh < 2u; kh = kh + 1u) {
+      for (var kw: u32 = 0u; kw < 2u; kw = kw + 1u) {
+        let ih = oh * 2u + kh;
+        let iw = ow * 2u + kw;
+        let val = input[c * params.IH * params.IW + ih * params.IW + iw];
+        max_val = max(max_val, val);
+      }
+    }
+    output[c * params.OH * params.OW + oh * params.OW + ow] = max_val;
+  }
+}

--- a/fuzz/corpus/fuzz_lower/reduce_sum.wgsl
+++ b/fuzz/corpus/fuzz_lower/reduce_sum.wgsl
@@ -1,0 +1,22 @@
+// Reduction sum over rows — target for NPU transpilation
+
+@group(0) @binding(0) var<storage, read> a: array<f32>;
+@group(0) @binding(1) var<storage, read_write> c: array<f32>;
+
+struct Params {
+  N: u32,
+}
+@group(0) @binding(2) var<uniform> params: Params;
+
+@compute @workgroup_size(256)
+fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
+  let row = gid.x;
+  if (row >= params.N) {
+    return;
+  }
+  var sum: f32 = 0.0;
+  for (var i: u32 = 0u; i < params.N; i = i + 1u) {
+    sum = sum + a[row * params.N + i];
+  }
+  c[row] = sum;
+}

--- a/fuzz/corpus/fuzz_lower/relu.wgsl
+++ b/fuzz/corpus/fuzz_lower/relu.wgsl
@@ -1,0 +1,18 @@
+// Element-wise ReLU activation — target for NPU transpilation
+
+@group(0) @binding(0) var<storage, read> a: array<f32>;
+@group(0) @binding(1) var<storage, read_write> c: array<f32>;
+
+struct Params {
+  N: u32,
+}
+@group(0) @binding(2) var<uniform> params: Params;
+
+@compute @workgroup_size(256)
+fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
+  let idx = gid.x;
+  if (idx >= params.N) {
+    return;
+  }
+  c[idx] = max(a[idx], 0.0);
+}

--- a/fuzz/corpus/fuzz_lower/split.wgsl
+++ b/fuzz/corpus/fuzz_lower/split.wgsl
@@ -1,0 +1,23 @@
+// Split a 1D array into two outputs at a given index.
+//
+// out_a[i] = input[i]              if i < split_at
+// out_b[i - split_at] = input[i]   otherwise
+
+@group(0) @binding(0) var<storage, read> input: array<f32>;
+@group(0) @binding(1) var<storage, read_write> out_a: array<f32>;
+@group(0) @binding(2) var<storage, read_write> out_b: array<f32>;
+
+struct Params { N: u32, split_at: u32 }
+@group(0) @binding(3) var<uniform> params: Params;
+
+@compute @workgroup_size(256)
+fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
+  let idx = gid.x;
+  if (idx >= params.N) { return; }
+
+  if (idx < params.split_at) {
+    out_a[idx] = input[idx];
+  } else {
+    out_b[idx - params.split_at] = input[idx];
+  }
+}

--- a/fuzz/corpus/fuzz_lower/tanh_act.wgsl
+++ b/fuzz/corpus/fuzz_lower/tanh_act.wgsl
@@ -1,0 +1,18 @@
+// Element-wise Tanh activation — target for NPU transpilation
+
+@group(0) @binding(0) var<storage, read> a: array<f32>;
+@group(0) @binding(1) var<storage, read_write> c: array<f32>;
+
+struct Params {
+  N: u32,
+}
+@group(0) @binding(2) var<uniform> params: Params;
+
+@compute @workgroup_size(256)
+fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
+  let idx = gid.x;
+  if (idx >= params.N) {
+    return;
+  }
+  c[idx] = tanh(a[idx]);
+}

--- a/fuzz/corpus/fuzz_lower/transpose.wgsl
+++ b/fuzz/corpus/fuzz_lower/transpose.wgsl
@@ -1,0 +1,20 @@
+// Matrix transpose — target for NPU transpilation
+
+@group(0) @binding(0) var<storage, read> a: array<f32>;
+@group(0) @binding(1) var<storage, read_write> c: array<f32>;
+
+struct Params {
+  rows: u32,
+  cols: u32,
+}
+@group(0) @binding(2) var<uniform> params: Params;
+
+@compute @workgroup_size(16, 16)
+fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
+  let row = gid.x;
+  let col = gid.y;
+  if (row >= params.rows || col >= params.cols) {
+    return;
+  }
+  c[col * params.rows + row] = a[row * params.cols + col];
+}

--- a/fuzz/corpus/fuzz_lower/vecadd.wgsl
+++ b/fuzz/corpus/fuzz_lower/vecadd.wgsl
@@ -1,0 +1,19 @@
+// Element-wise vector addition — target for NPU transpilation
+
+@group(0) @binding(0) var<storage, read> a: array<f32>;
+@group(0) @binding(1) var<storage, read> b: array<f32>;
+@group(0) @binding(2) var<storage, read_write> c: array<f32>;
+
+struct Params {
+  N: u32,
+}
+@group(0) @binding(3) var<uniform> params: Params;
+
+@compute @workgroup_size(256)
+fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
+  let idx = gid.x;
+  if (idx >= params.N) {
+    return;
+  }
+  c[idx] = a[idx] + b[idx];
+}

--- a/fuzz/corpus/fuzz_lower/vecmul.wgsl
+++ b/fuzz/corpus/fuzz_lower/vecmul.wgsl
@@ -1,0 +1,19 @@
+// Element-wise vector multiplication — target for NPU transpilation
+
+@group(0) @binding(0) var<storage, read> a: array<f32>;
+@group(0) @binding(1) var<storage, read> b: array<f32>;
+@group(0) @binding(2) var<storage, read_write> c: array<f32>;
+
+struct Params {
+  N: u32,
+}
+@group(0) @binding(3) var<uniform> params: Params;
+
+@compute @workgroup_size(256)
+fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
+  let idx = gid.x;
+  if (idx >= params.N) {
+    return;
+  }
+  c[idx] = a[idx] * b[idx];
+}

--- a/fuzz/corpus/fuzz_lower/vecsub.wgsl
+++ b/fuzz/corpus/fuzz_lower/vecsub.wgsl
@@ -1,0 +1,19 @@
+// Element-wise vector subtraction — target for NPU transpilation
+
+@group(0) @binding(0) var<storage, read> a: array<f32>;
+@group(0) @binding(1) var<storage, read> b: array<f32>;
+@group(0) @binding(2) var<storage, read_write> c: array<f32>;
+
+struct Params {
+  N: u32,
+}
+@group(0) @binding(3) var<uniform> params: Params;
+
+@compute @workgroup_size(256)
+fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
+  let idx = gid.x;
+  if (idx >= params.N) {
+    return;
+  }
+  c[idx] = a[idx] - b[idx];
+}

--- a/fuzz/corpus/fuzz_parse/attention.wgsl
+++ b/fuzz/corpus/fuzz_parse/attention.wgsl
@@ -1,0 +1,51 @@
+// Scaled dot-product attention.
+//
+// attn = softmax(Q * K^T / sqrt(d_k)) * V
+//
+// For each query position, computes attention scores against all key positions,
+// applies numerically stable softmax, then weights values.
+
+@group(0) @binding(0) var<storage, read> query: array<f32>;
+@group(0) @binding(1) var<storage, read> key: array<f32>;
+@group(0) @binding(2) var<storage, read> value: array<f32>;
+@group(0) @binding(3) var<storage, read_write> output: array<f32>;
+
+struct Params { seq_len: u32, d_k: u32 }
+@group(0) @binding(4) var<uniform> params: Params;
+
+@compute @workgroup_size(16, 16)
+fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
+  let row = gid.x;
+  let col = gid.y;
+  if (row >= params.seq_len || col >= params.d_k) { return; }
+
+  let scale = 1.0 / sqrt(f32(params.d_k));
+
+  // Compute attention scores: Q[row,:] dot K[j,:] for all j
+  // Then softmax over j dimension
+  var max_score: f32 = -1e30;
+  for (var j: u32 = 0u; j < params.seq_len; j = j + 1u) {
+    var score: f32 = 0.0;
+    for (var k: u32 = 0u; k < params.d_k; k = k + 1u) {
+      score = score + query[row * params.d_k + k] * key[j * params.d_k + k];
+    }
+    score = score * scale;
+    max_score = max(max_score, score);
+  }
+
+  // Compute softmax denominator and weighted sum
+  var sum_exp: f32 = 0.0;
+  var result: f32 = 0.0;
+  for (var j: u32 = 0u; j < params.seq_len; j = j + 1u) {
+    var score: f32 = 0.0;
+    for (var k: u32 = 0u; k < params.d_k; k = k + 1u) {
+      score = score + query[row * params.d_k + k] * key[j * params.d_k + k];
+    }
+    score = score * scale;
+    let w = exp(score - max_score);
+    sum_exp = sum_exp + w;
+    result = result + w * value[j * params.d_k + col];
+  }
+
+  output[row * params.d_k + col] = result / sum_exp;
+}

--- a/fuzz/corpus/fuzz_parse/batchnorm.wgsl
+++ b/fuzz/corpus/fuzz_parse/batchnorm.wgsl
@@ -1,0 +1,45 @@
+// Batch normalization — target for NPU transpilation
+// y = gamma * (x - mean) / sqrt(variance + epsilon) + beta
+
+@group(0) @binding(0) var<storage, read> x: array<f32>;
+@group(0) @binding(1) var<storage, read> gamma: array<f32>;
+@group(0) @binding(2) var<storage, read> beta: array<f32>;
+@group(0) @binding(3) var<storage, read_write> y: array<f32>;
+
+struct Params {
+  N: u32,
+  C: u32,
+  HW: u32,
+}
+@group(0) @binding(4) var<uniform> params: Params;
+
+@compute @workgroup_size(256)
+fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
+  let idx = gid.x;
+  let total = params.N * params.C * params.HW;
+  if (idx >= total) {
+    return;
+  }
+  let c = (idx / params.HW) % params.C;
+
+  // Compute channel mean
+  var mean: f32 = 0.0;
+  let ch_start = (idx / (params.C * params.HW)) * params.C * params.HW + c * params.HW;
+  for (var i: u32 = 0u; i < params.HW; i = i + 1u) {
+    mean = mean + x[ch_start + i];
+  }
+  mean = mean / f32(params.HW);
+
+  // Compute channel variance
+  var variance: f32 = 0.0;
+  for (var i: u32 = 0u; i < params.HW; i = i + 1u) {
+    let diff = x[ch_start + i] - mean;
+    variance = variance + diff * diff;
+  }
+  variance = variance / f32(params.HW);
+
+  // Normalize
+  let epsilon: f32 = 1e-5;
+  let normalized = (x[idx] - mean) / sqrt(variance + epsilon);
+  y[idx] = gamma[c] * normalized + beta[c];
+}

--- a/fuzz/corpus/fuzz_parse/concat.wgsl
+++ b/fuzz/corpus/fuzz_parse/concat.wgsl
@@ -1,0 +1,24 @@
+// Concatenate two 1D arrays along axis 0.
+//
+// output[i] = a[i]           if i < N_a
+// output[i] = b[i - N_a]    otherwise
+
+@group(0) @binding(0) var<storage, read> a: array<f32>;
+@group(0) @binding(1) var<storage, read> b: array<f32>;
+@group(0) @binding(2) var<storage, read_write> output: array<f32>;
+
+struct Params { N_a: u32, N_b: u32 }
+@group(0) @binding(3) var<uniform> params: Params;
+
+@compute @workgroup_size(256)
+fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
+  let idx = gid.x;
+  let total = params.N_a + params.N_b;
+  if (idx >= total) { return; }
+
+  if (idx < params.N_a) {
+    output[idx] = a[idx];
+  } else {
+    output[idx] = b[idx - params.N_a];
+  }
+}

--- a/fuzz/corpus/fuzz_parse/conv2d.wgsl
+++ b/fuzz/corpus/fuzz_parse/conv2d.wgsl
@@ -1,0 +1,43 @@
+// 2D convolution — target for NPU transpilation
+
+@group(0) @binding(0) var<storage, read> input: array<f32>;
+@group(0) @binding(1) var<storage, read> weight: array<f32>;
+@group(0) @binding(2) var<storage, read_write> output: array<f32>;
+
+struct Params {
+  N: u32,
+  IC: u32,
+  IH: u32,
+  IW: u32,
+  OC: u32,
+  KH: u32,
+  KW: u32,
+}
+@group(0) @binding(3) var<uniform> params: Params;
+
+@compute @workgroup_size(16, 16)
+fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
+  let oc = gid.x;
+  let oh = gid.y;
+  if (oc >= params.OC) {
+    return;
+  }
+
+  let ow_max = params.IW - params.KW + 1u;
+  for (var ow: u32 = 0u; ow < ow_max; ow = ow + 1u) {
+    var sum: f32 = 0.0;
+    for (var kh: u32 = 0u; kh < params.KH; kh = kh + 1u) {
+      for (var kw: u32 = 0u; kw < params.KW; kw = kw + 1u) {
+        for (var ic: u32 = 0u; ic < params.IC; ic = ic + 1u) {
+          let ih = oh + kh;
+          let iw = ow + kw;
+          let in_idx = ic * params.IH * params.IW + ih * params.IW + iw;
+          let w_idx = oc * params.IC * params.KH * params.KW + ic * params.KH * params.KW + kh * params.KW + kw;
+          sum = sum + input[in_idx] * weight[w_idx];
+        }
+      }
+    }
+    let out_idx = oc * (params.IH - params.KH + 1u) * ow_max + oh * ow_max + ow;
+    output[out_idx] = sum;
+  }
+}

--- a/fuzz/corpus/fuzz_parse/matmul.wgsl
+++ b/fuzz/corpus/fuzz_parse/matmul.wgsl
@@ -1,0 +1,28 @@
+// Matrix multiplication — target for NPU transpilation
+
+@group(0) @binding(0) var<storage, read> a: array<f32>;
+@group(0) @binding(1) var<storage, read> b: array<f32>;
+@group(0) @binding(2) var<storage, read_write> result: array<f32>;
+
+struct Params {
+  M: u32,
+  N: u32,
+  K: u32,
+}
+@group(0) @binding(3) var<uniform> params: Params;
+
+@compute @workgroup_size(16, 16)
+fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
+  let row = gid.x;
+  let col = gid.y;
+
+  if (row >= params.M || col >= params.N) {
+    return;
+  }
+
+  var sum: f32 = 0.0;
+  for (var k: u32 = 0u; k < params.K; k = k + 1u) {
+    sum = sum + a[row * params.K + k] * b[k * params.N + col];
+  }
+  result[row * params.N + col] = sum;
+}

--- a/fuzz/corpus/fuzz_parse/maxpool.wgsl
+++ b/fuzz/corpus/fuzz_parse/maxpool.wgsl
@@ -1,0 +1,35 @@
+// Max pooling 2D (2x2 kernel, stride 2) — target for NPU transpilation
+
+@group(0) @binding(0) var<storage, read> input: array<f32>;
+@group(0) @binding(1) var<storage, read_write> output: array<f32>;
+
+struct Params {
+  C: u32,
+  IH: u32,
+  IW: u32,
+  OH: u32,
+  OW: u32,
+}
+@group(0) @binding(2) var<uniform> params: Params;
+
+@compute @workgroup_size(16, 16)
+fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
+  let c = gid.x;
+  let oh = gid.y;
+  if (c >= params.C || oh >= params.OH) {
+    return;
+  }
+
+  for (var ow: u32 = 0u; ow < params.OW; ow = ow + 1u) {
+    var max_val: f32 = -3.402823e+38;
+    for (var kh: u32 = 0u; kh < 2u; kh = kh + 1u) {
+      for (var kw: u32 = 0u; kw < 2u; kw = kw + 1u) {
+        let ih = oh * 2u + kh;
+        let iw = ow * 2u + kw;
+        let val = input[c * params.IH * params.IW + ih * params.IW + iw];
+        max_val = max(max_val, val);
+      }
+    }
+    output[c * params.OH * params.OW + oh * params.OW + ow] = max_val;
+  }
+}

--- a/fuzz/corpus/fuzz_parse/reduce_sum.wgsl
+++ b/fuzz/corpus/fuzz_parse/reduce_sum.wgsl
@@ -1,0 +1,22 @@
+// Reduction sum over rows — target for NPU transpilation
+
+@group(0) @binding(0) var<storage, read> a: array<f32>;
+@group(0) @binding(1) var<storage, read_write> c: array<f32>;
+
+struct Params {
+  N: u32,
+}
+@group(0) @binding(2) var<uniform> params: Params;
+
+@compute @workgroup_size(256)
+fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
+  let row = gid.x;
+  if (row >= params.N) {
+    return;
+  }
+  var sum: f32 = 0.0;
+  for (var i: u32 = 0u; i < params.N; i = i + 1u) {
+    sum = sum + a[row * params.N + i];
+  }
+  c[row] = sum;
+}

--- a/fuzz/corpus/fuzz_parse/relu.wgsl
+++ b/fuzz/corpus/fuzz_parse/relu.wgsl
@@ -1,0 +1,18 @@
+// Element-wise ReLU activation — target for NPU transpilation
+
+@group(0) @binding(0) var<storage, read> a: array<f32>;
+@group(0) @binding(1) var<storage, read_write> c: array<f32>;
+
+struct Params {
+  N: u32,
+}
+@group(0) @binding(2) var<uniform> params: Params;
+
+@compute @workgroup_size(256)
+fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
+  let idx = gid.x;
+  if (idx >= params.N) {
+    return;
+  }
+  c[idx] = max(a[idx], 0.0);
+}

--- a/fuzz/corpus/fuzz_parse/split.wgsl
+++ b/fuzz/corpus/fuzz_parse/split.wgsl
@@ -1,0 +1,23 @@
+// Split a 1D array into two outputs at a given index.
+//
+// out_a[i] = input[i]              if i < split_at
+// out_b[i - split_at] = input[i]   otherwise
+
+@group(0) @binding(0) var<storage, read> input: array<f32>;
+@group(0) @binding(1) var<storage, read_write> out_a: array<f32>;
+@group(0) @binding(2) var<storage, read_write> out_b: array<f32>;
+
+struct Params { N: u32, split_at: u32 }
+@group(0) @binding(3) var<uniform> params: Params;
+
+@compute @workgroup_size(256)
+fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
+  let idx = gid.x;
+  if (idx >= params.N) { return; }
+
+  if (idx < params.split_at) {
+    out_a[idx] = input[idx];
+  } else {
+    out_b[idx - params.split_at] = input[idx];
+  }
+}

--- a/fuzz/corpus/fuzz_parse/tanh_act.wgsl
+++ b/fuzz/corpus/fuzz_parse/tanh_act.wgsl
@@ -1,0 +1,18 @@
+// Element-wise Tanh activation — target for NPU transpilation
+
+@group(0) @binding(0) var<storage, read> a: array<f32>;
+@group(0) @binding(1) var<storage, read_write> c: array<f32>;
+
+struct Params {
+  N: u32,
+}
+@group(0) @binding(2) var<uniform> params: Params;
+
+@compute @workgroup_size(256)
+fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
+  let idx = gid.x;
+  if (idx >= params.N) {
+    return;
+  }
+  c[idx] = tanh(a[idx]);
+}

--- a/fuzz/corpus/fuzz_parse/transpose.wgsl
+++ b/fuzz/corpus/fuzz_parse/transpose.wgsl
@@ -1,0 +1,20 @@
+// Matrix transpose — target for NPU transpilation
+
+@group(0) @binding(0) var<storage, read> a: array<f32>;
+@group(0) @binding(1) var<storage, read_write> c: array<f32>;
+
+struct Params {
+  rows: u32,
+  cols: u32,
+}
+@group(0) @binding(2) var<uniform> params: Params;
+
+@compute @workgroup_size(16, 16)
+fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
+  let row = gid.x;
+  let col = gid.y;
+  if (row >= params.rows || col >= params.cols) {
+    return;
+  }
+  c[col * params.rows + row] = a[row * params.cols + col];
+}

--- a/fuzz/corpus/fuzz_parse/vecadd.wgsl
+++ b/fuzz/corpus/fuzz_parse/vecadd.wgsl
@@ -1,0 +1,19 @@
+// Element-wise vector addition — target for NPU transpilation
+
+@group(0) @binding(0) var<storage, read> a: array<f32>;
+@group(0) @binding(1) var<storage, read> b: array<f32>;
+@group(0) @binding(2) var<storage, read_write> c: array<f32>;
+
+struct Params {
+  N: u32,
+}
+@group(0) @binding(3) var<uniform> params: Params;
+
+@compute @workgroup_size(256)
+fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
+  let idx = gid.x;
+  if (idx >= params.N) {
+    return;
+  }
+  c[idx] = a[idx] + b[idx];
+}

--- a/fuzz/corpus/fuzz_parse/vecmul.wgsl
+++ b/fuzz/corpus/fuzz_parse/vecmul.wgsl
@@ -1,0 +1,19 @@
+// Element-wise vector multiplication — target for NPU transpilation
+
+@group(0) @binding(0) var<storage, read> a: array<f32>;
+@group(0) @binding(1) var<storage, read> b: array<f32>;
+@group(0) @binding(2) var<storage, read_write> c: array<f32>;
+
+struct Params {
+  N: u32,
+}
+@group(0) @binding(3) var<uniform> params: Params;
+
+@compute @workgroup_size(256)
+fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
+  let idx = gid.x;
+  if (idx >= params.N) {
+    return;
+  }
+  c[idx] = a[idx] * b[idx];
+}

--- a/fuzz/corpus/fuzz_parse/vecsub.wgsl
+++ b/fuzz/corpus/fuzz_parse/vecsub.wgsl
@@ -1,0 +1,19 @@
+// Element-wise vector subtraction — target for NPU transpilation
+
+@group(0) @binding(0) var<storage, read> a: array<f32>;
+@group(0) @binding(1) var<storage, read> b: array<f32>;
+@group(0) @binding(2) var<storage, read_write> c: array<f32>;
+
+struct Params {
+  N: u32,
+}
+@group(0) @binding(3) var<uniform> params: Params;
+
+@compute @workgroup_size(256)
+fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
+  let idx = gid.x;
+  if (idx >= params.N) {
+    return;
+  }
+  c[idx] = a[idx] - b[idx];
+}

--- a/fuzz/fuzz_targets/fuzz_lower.rs
+++ b/fuzz/fuzz_targets/fuzz_lower.rs
@@ -1,0 +1,10 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    if let Ok(source) = std::str::from_utf8(data) {
+        // The full parse + lower pipeline should never panic.
+        let _ = nxpu_parser::parse(source);
+    }
+});

--- a/fuzz/fuzz_targets/fuzz_parse.rs
+++ b/fuzz/fuzz_targets/fuzz_parse.rs
@@ -1,0 +1,10 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    if let Ok(source) = std::str::from_utf8(data) {
+        // naga's WGSL parser should never panic on any input.
+        let _ = naga::front::wgsl::parse_str(source);
+    }
+});


### PR DESCRIPTION
## Summary

- Add `fuzz_parse` target — fuzzes naga's WGSL parser with arbitrary bytes
- Add `fuzz_lower` target — fuzzes the full parse + IR lowering pipeline
- Seed corpus from all 14 example WGSL files
- Add fuzzing instructions to CONTRIBUTING.md

Tested locally: ~1M runs across both targets with zero crashes.

Closes #105

## Test plan

- [x] `cargo +nightly fuzz build` compiles both targets
- [x] `cargo +nightly fuzz run fuzz_parse -- -max_total_time=20` — 534K runs, no crashes
- [x] `cargo +nightly fuzz run fuzz_lower -- -max_total_time=20` — 445K runs, no crashes

🤖 Generated with [Claude Code](https://claude.com/claude-code)